### PR TITLE
PAE-142: fix development syncing in docker compose

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,23 @@
+ARG PARENT_VERSION=2.5.2-node22.13.1
+ARG PORT=3000
+ARG PORT_DEBUG=9229
+
+FROM defradigital/node-development:${PARENT_VERSION}
+
+WORKDIR /app
+
+ENV TZ="Europe/London"
+
+ARG PARENT_VERSION
+LABEL uk.gov.defra.ffc.parent-image=defradigital/node-development:${PARENT_VERSION}
+
+ARG PORT
+ARG PORT_DEBUG
+ENV PORT=${PORT}
+EXPOSE ${PORT} ${PORT_DEBUG}
+
+COPY --chown=node:node --chmod=755 package*.json nodemon.json tsconfig.json babel.config.cjs webpack.config.js .browserslistrc ./
+COPY --chown=node:node --chmod=755 src/ ./src/
+RUN npm install --ignore-scripts
+
+CMD [ "npm", "run", "dev" ]

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ docker run -p 3000:3000 epr-frontend
 
 ### Docker Compose
 
+> [!IMPORTANT]
+>
+> Please ensure you have at least version 2.22.0 of Docker Compose installed.
+
 A local environment with:
 
 - Localstack for AWS services (S3, SQS)
@@ -177,7 +181,7 @@ A local environment with:
 - A commented out backend example.
 
 ```bash
-docker compose up --build -d
+docker compose up --build -d --watch
 ```
 
 ### Dependabot

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
   localstack:
@@ -32,25 +31,36 @@ services:
     networks:
       - cdp-tenant
 
-  mongodb:
-    image: mongo:6.0.13
-    networks:
-      - cdp-tenant
-    ports:
-      - '27017:27017'
-    volumes:
-      - mongodb-data:/data
-    restart: always
-
 ################################################################################
 
-  your-frontend:
-    build: ./
+  ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.local
     ports:
       - '3000:3000'
     links:
       - 'localstack:localstack'
       - 'redis:redis'
+    develop:
+      watch:
+        - path: src/
+          action: sync
+          target: /app/src/
+          ignore:
+            - node_modules/
+        - path: .browserslistrc
+          action: rebuild
+        - path: babel.config.cjs
+          action: rebuild
+        - path: nodemon.json
+          action: rebuild
+        - path: package.json
+          action: rebuild
+        - path: tsconfig.json
+          action: rebuild
+        - path: webpack.config.js
+          action: rebuild
     depends_on:
       localstack:
         condition: service_healthy
@@ -89,9 +99,6 @@ services:
   #     - cdp-tenant
 
 ################################################################################
-
-volumes:
-  mongodb-data:
 
 networks:
   cdp-tenant:


### PR DESCRIPTION
## Description

1. Create local Dockerfile that doesn't rely on built artifacts
2. Add Docker Compose `watch` config
3. Update docs to highlight Docker Compose required version

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
