### PR TITLE
PAE-264: Add Github actions to run journey tests on PR and update README on docker compose instruction

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -83,3 +83,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  test-journey:
+    name: Run Journey Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: docker build -t defradigital/epr-frontend:${{github.sha}} .
+      - uses: DEFRA/epr-frontend-journey-tests/run-journey-tests@main
+        with:
+          epr-frontend: ${{github.sha}}
+          branch: main

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ A local environment with:
 - A commented out backend example.
 
 ```bash
-docker compose up --build -d --watch
+docker compose up --build --watch
 ```
 
 ### Dependabot


### PR DESCRIPTION
## Description

- Add Github actions to run epr-frontend-journey test as part of PR
- Update README on Docker compose command as --watch does not work in detached mode ( -d ) 
