### PR TITLE
PAE-271: remove declaration from summary log upload

### DIFF
--- a/src/server/summary-log-upload/index.njk
+++ b/src/server/summary-log-upload/index.njk
@@ -80,15 +80,11 @@
           id: "summary-log-upload",
           name: "summaryLogUpload",
           label: {
-            text: "Upload XLSX"
+            text: "Upload XLSX file"
           },
           javascript: true
         }) }}
 
-        <h2 class="govuk-heading-m">Declaration</h2>
-        <p>
-          By submitting this summary log you confirm that, to the best of your knowledge, the packaging waste records you’re providing are correct.
-        </p>
         {{ govukButton({
           text: 'Continue'
         }) }}


### PR DESCRIPTION
## Description

1. Remove declaration that was only present in old designs
2. Add missing "file" from upload field label

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
