### PR TITLE
PAE-000: bypass branch name checks for snyk

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check branch name
         uses: actions/github-script@v8
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'snyk-upgrade-') }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -31,7 +31,7 @@ jobs:
             }
       - name: Add ticket link to PR description
         uses: actions/github-script@v8
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'snyk-upgrade-') }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
## Description

Allow snyk branches to bypass the branch name requirements - which is [causing Snyk patches to fail in this repo ](https://github.com/DEFRA/epr-frontend/actions/runs/18255809664/job/51976881843?pr=91#step:2:20)

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).
