### PR TITLE
PAE-000: Redirect-based token refresh to avoid inflating average response time

### DIFF
--- a/src/server/auth/helpers/session-cookie.js
+++ b/src/server/auth/helpers/session-cookie.js
@@ -4,6 +4,7 @@ import {
   removeUserSession,
   updateUserSession
 } from '#server/auth/helpers/user-session.js'
+import { paths } from '#server/paths.js'
 import authCookie from '@hapi/cookie'
 import { isPast, parseISO, subMinutes, subSeconds } from 'date-fns'
 import { getUserSession } from './get-user-session.js'
@@ -172,6 +173,9 @@ const createSessionCookie = (verifyToken) => {
       register: async (server) => {
         await server.register(authCookie)
 
+        // Expose blockingRefresh for the /auth/refresh endpoint
+        server.app.blockingRefresh = blockingRefresh
+
         server.auth.strategy('session', 'cookie', {
           cookie: {
             name: 'userSession',
@@ -197,7 +201,17 @@ const createSessionCookie = (verifyToken) => {
 
             // Note this first check also catches an expired session
             if (userSessionExpires(userSession, inNext10Seconds)) {
-              return blockingRefresh(request, userSession)
+              if (request.method === 'get') {
+                // Flag for onPostAuth to redirect to /auth/refresh.
+                // This moves the slow OIDC token refresh off the page
+                // response time, avoiding false alerts on the CDP
+                // average response time metric.
+                request.app.needsTokenRefreshRedirect = true
+              } else {
+                // Non-GET requests (e.g. POST) still use inline blocking
+                // refresh because a redirect would lose the request body
+                return blockingRefresh(request, userSession)
+              }
             } else if (userSessionExpires(userSession, inNext5Minutes)) {
               backgroundRefresh(request, userSession)
             } else {
@@ -212,6 +226,24 @@ const createSessionCookie = (verifyToken) => {
         })
 
         server.auth.default('session')
+
+        // Redirect expired GET requests to /auth/refresh instead of
+        // blocking inline. The refresh endpoint is a distinct URL that
+        // can be excluded from the CDP response time alert.
+        server.ext('onPostAuth', (request, h) => {
+          if (
+            request.app.needsTokenRefreshRedirect &&
+            request.path !== paths.auth.refresh
+          ) {
+            const returnTo = `${request.url.pathname}${request.url.search}`
+            return h
+              .redirect(
+                `${paths.auth.refresh}?returnTo=${encodeURIComponent(returnTo)}`
+              )
+              .takeover()
+          }
+          return h.continue
+        })
       }
     }
   }

--- a/src/server/auth/helpers/session-cookie.test.js
+++ b/src/server/auth/helpers/session-cookie.test.js
@@ -77,19 +77,27 @@ describe('#sessionCookie - integration', () => {
       }
     })
 
+    const testHandler = (request) => ({
+      userId: request.auth.credentials.profile.id,
+      email: request.auth.credentials.profile.email,
+      idToken: request.auth.credentials.idToken
+    })
+
     beforeEach(({ server }) => {
-      server.route({
-        method: 'GET',
-        path: '/test-auth',
-        options: {
-          auth: 'session'
+      server.route([
+        {
+          method: 'GET',
+          path: '/test-auth',
+          options: { auth: 'session' },
+          handler: testHandler
         },
-        handler: (request) => ({
-          userId: request.auth.credentials.profile.id,
-          email: request.auth.credentials.profile.email,
-          idToken: request.auth.credentials.idToken
-        })
-      })
+        {
+          method: 'POST',
+          path: '/test-auth',
+          options: { auth: 'session', plugins: { crumb: false } },
+          handler: testHandler
+        }
+      ])
     })
 
     it('should refresh token in background when token expires within 5 minutes', async ({
@@ -419,7 +427,82 @@ describe('#sessionCookie - integration', () => {
       )
     })
 
-    it('should await refresh and update session before response when token expires within 10 seconds', async ({
+    it('should redirect GET request to /auth/refresh when token expires within 10 seconds', async ({
+      server
+    }) => {
+      const timerSpy = vi.spyOn(Metrics.prototype, 'timer')
+
+      // Expires in 5 seconds: within the 10-second awaited-refresh window
+      const expiresAt = addSeconds(new Date(), 5).toISOString()
+      const { sessionId, sessionData } = createExpiredRefreshSessionData(
+        'user-awaited',
+        expiresAt
+      )
+
+      await server.app.cache.set(sessionId, sessionData)
+
+      const cookiePassword = config.get('session.cookie.password')
+      const sealedCookie = await Iron.seal(
+        { sessionId },
+        cookiePassword,
+        Iron.defaults
+      )
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/test-auth',
+        headers: {
+          cookie: `userSession=${sealedCookie}`
+        }
+      })
+
+      // GET request is redirected to /auth/refresh instead of blocking
+      expect(response.statusCode).toBe(statusCodes.found)
+      expect(response.headers.location).toBe(
+        '/auth/refresh?returnTo=%2Ftest-auth'
+      )
+
+      // No refresh happened yet — just a redirect
+      expect(timerSpy).not.toHaveBeenCalled()
+
+      // Session is unchanged in cache
+      const unchangedSession = await server.app.cache.get(sessionId)
+      expect(unchangedSession.idToken).toBe(sessionData.idToken)
+    })
+
+    it('should preserve query string in returnTo when redirecting to /auth/refresh', async ({
+      server
+    }) => {
+      const expiresAt = addSeconds(new Date(), 5).toISOString()
+      const { sessionId, sessionData } = createExpiredRefreshSessionData(
+        'user-query-string',
+        expiresAt
+      )
+
+      await server.app.cache.set(sessionId, sessionData)
+
+      const cookiePassword = config.get('session.cookie.password')
+      const sealedCookie = await Iron.seal(
+        { sessionId },
+        cookiePassword,
+        Iron.defaults
+      )
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/test-auth?page=2&sort=date',
+        headers: {
+          cookie: `userSession=${sealedCookie}`
+        }
+      })
+
+      expect(response.statusCode).toBe(statusCodes.found)
+      expect(response.headers.location).toBe(
+        '/auth/refresh?returnTo=%2Ftest-auth%3Fpage%3D2%26sort%3Ddate'
+      )
+    })
+
+    it('should perform blocking refresh inline for POST request when token expires within 10 seconds', async ({
       server,
       msw
     }) => {
@@ -440,7 +523,7 @@ describe('#sessionCookie - integration', () => {
       // Expires in 5 seconds: within the 10-second awaited-refresh window
       const expiresAt = addSeconds(new Date(), 5).toISOString()
       const { sessionId, sessionData } = createExpiredRefreshSessionData(
-        'user-awaited',
+        'user-post',
         expiresAt
       )
 
@@ -457,8 +540,10 @@ describe('#sessionCookie - integration', () => {
         Iron.defaults
       )
 
+      // POST requests still use inline blocking refresh to avoid losing
+      // the request body in a redirect
       const response = await server.inject({
-        method: 'GET',
+        method: 'POST',
         url: '/test-auth',
         headers: {
           cookie: `userSession=${sealedCookie}`
@@ -469,11 +554,6 @@ describe('#sessionCookie - integration', () => {
 
       const updatedSession = await server.app.cache.get(sessionId)
       expect(updatedSession.refreshToken).toBe('awaited-new-refresh-token')
-      const newExpiresAt = new Date(updatedSession.expiresAt)
-      expect(newExpiresAt.getTime()).toBeGreaterThan(Date.now())
-
-      const payload = JSON.parse(response.payload)
-      expect(updatedSession.idToken).toBe(payload.idToken)
 
       expect(timerSpy).toHaveBeenCalledExactlyOnceWith(
         'tokenRefreshDuration',
@@ -482,7 +562,7 @@ describe('#sessionCookie - integration', () => {
       )
     })
 
-    it('should drop session synchronously when awaited refresh fails for token expiring within 10 seconds', async ({
+    it('should drop session for POST request when inline blocking refresh fails', async ({
       server,
       msw
     }) => {
@@ -503,7 +583,7 @@ describe('#sessionCookie - integration', () => {
       // Expires in 5 seconds: within the 10-second awaited-refresh window
       const expiresAt = addSeconds(new Date(), 5).toISOString()
       const { sessionId, sessionData } = createExpiredRefreshSessionData(
-        'user-awaited-fail',
+        'user-post-fail',
         expiresAt
       )
 
@@ -517,7 +597,7 @@ describe('#sessionCookie - integration', () => {
       )
 
       const response = await server.inject({
-        method: 'GET',
+        method: 'POST',
         url: '/test-auth',
         headers: {
           cookie: `userSession=${sealedCookie}`
@@ -529,59 +609,6 @@ describe('#sessionCookie - integration', () => {
 
       const removedSession = await server.app.cache.get(sessionId)
       expect(removedSession).toBeNull()
-
-      expect(timerSpy).toHaveBeenCalledExactlyOnceWith(
-        'tokenRefreshDuration',
-        expect.any(Function),
-        { type: 'blocking' }
-      )
-    })
-
-    it('should skip refresh when idTokenRefreshInProgress is already set', async ({
-      server
-    }) => {
-      const timerSpy = vi.spyOn(Metrics.prototype, 'timer')
-      // Expires in 5 seconds: would normally trigger an awaited refresh
-      const expiresAt = addSeconds(new Date(), 5).toISOString()
-      const sessionId = 'test-session-in-progress'
-
-      const sessionData = {
-        profile: { id: 'user-in-progress', email: 'inprogress@example.com' },
-        expiresAt,
-        idToken: 'old-id-token-in-progress',
-        refreshToken: 'old-refresh-token-in-progress',
-        idTokenRefreshInProgress: true,
-        urls: {
-          token: 'http://defra-id.auth/token',
-          logout: 'http://defra-id.auth/logout'
-        }
-      }
-
-      await server.app.cache.set(sessionId, sessionData)
-
-      const cookiePassword = config.get('session.cookie.password')
-      const sealedCookie = await Iron.seal(
-        { sessionId },
-        cookiePassword,
-        Iron.defaults
-      )
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/test-auth',
-        headers: {
-          cookie: `userSession=${sealedCookie}`
-        }
-      })
-
-      expect(response.statusCode).toBe(statusCodes.ok)
-
-      // Session must be unchanged: refresh was skipped because it was already in progress
-      const unchangedSession = await server.app.cache.get(sessionId)
-      expect(unchangedSession.idToken).toBe('old-id-token-in-progress')
-      expect(unchangedSession.refreshToken).toBe(
-        'old-refresh-token-in-progress'
-      )
 
       expect(timerSpy).toHaveBeenCalledExactlyOnceWith(
         'tokenRefreshDuration',

--- a/src/server/auth/index.js
+++ b/src/server/auth/index.js
@@ -1,10 +1,11 @@
 import { controller as callbackController } from '#server/auth/callback/controller.js'
 import { controller as organisationController } from '#server/auth/organisation/controller.js'
+import { controller as refreshController } from '#server/auth/refresh/controller.js'
 import { paths } from '#server/paths.js'
 
 /**
  * Auth plugin
- * Registers auth routes for OAuth2/OIDC callback, organisation selection, and logout callback
+ * Registers auth routes for OAuth2/OIDC callback, organisation selection, token refresh, and logout callback
  */
 const auth = {
   plugin: {
@@ -27,6 +28,11 @@ const auth = {
           ...organisationController,
           method: 'GET',
           path: paths.auth.organisation
+        },
+        {
+          ...refreshController,
+          method: 'GET',
+          path: paths.auth.refresh
         }
       ])
     }

--- a/src/server/auth/refresh/controller.js
+++ b/src/server/auth/refresh/controller.js
@@ -1,0 +1,54 @@
+import { paths } from '#server/paths.js'
+
+/**
+ * @import { Request, ResponseToolkit } from '@hapi/hapi'
+ */
+
+/**
+ * Validates that a returnTo URL is a safe same-origin path.
+ * Rejects absolute URLs, protocol-relative URLs, and non-string values.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isSafeReturnTo(value) {
+  return (
+    typeof value === 'string' &&
+    value.startsWith('/') &&
+    !value.startsWith('//')
+  )
+}
+
+/**
+ * Controller for the /auth/refresh endpoint.
+ * Performs a blocking token refresh and redirects back to the original page.
+ * This endpoint exists so that the slow OIDC round-trip happens on a
+ * dedicated URL rather than inflating average page response times.
+ */
+const controller = {
+  options: {
+    auth: 'session'
+  },
+  /**
+   * @param {Request} request
+   * @param {ResponseToolkit} h
+   */
+  handler: async (request, h) => {
+    const userSession = request.auth.credentials
+    const returnTo = isSafeReturnTo(request.query.returnTo)
+      ? request.query.returnTo
+      : '/'
+
+    const result = await request.server.app.blockingRefresh(
+      request,
+      userSession
+    )
+
+    if (result.isValid) {
+      return h.redirect(returnTo)
+    }
+
+    return h.redirect(request.localiseUrl(paths.loggedOut))
+  }
+}
+
+export { controller }

--- a/src/server/auth/refresh/get.integration.test.js
+++ b/src/server/auth/refresh/get.integration.test.js
@@ -1,0 +1,333 @@
+import { config } from '#config/config.js'
+import { statusCodes } from '#server/common/constants/status-codes.js'
+import { it } from '#vite/fixtures/server.js'
+import { Metrics } from '@defra/cdp-metrics'
+import Iron from '@hapi/iron'
+import { addSeconds } from 'date-fns'
+import * as jose from 'jose'
+import { http, HttpResponse } from 'msw'
+import { afterEach, describe, expect, vi } from 'vitest'
+
+vi.mock(import('#server/auth/helpers/verify-token.js'), () => ({
+  getVerifyToken: vi.fn(async () => (token) => jose.decodeJwt(token))
+}))
+
+const createFakeJwt = (payload) => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'RS256', typ: 'JWT' })
+  ).toString('base64url')
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url'
+  )
+  return `${header}.${encodedPayload}.fake-signature`
+}
+
+const defaultJwtPayload = {
+  aal: '1',
+  contactId: 'contact-123',
+  correlationId: 'corr-123',
+  currentRelationshipId: 'rel-123',
+  email: 'test@example.com',
+  enrolmentCount: 1,
+  enrolmentRequestCount: 0,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  firstName: 'Test',
+  lastName: 'User',
+  loa: '2',
+  relationships: ['rel-123'],
+  roles: ['role1'],
+  serviceId: 'test-service-id',
+  sessionId: 'sess-123',
+  sub: 'user-123',
+  uniqueReference: 'ref-123'
+}
+
+/**
+ * @param {string} userId
+ * @param {string} expiresAt
+ */
+const createExpiredSessionData = (userId, expiresAt) => ({
+  sessionId: `test-session-${userId}`,
+  sessionData: {
+    profile: {
+      id: userId,
+      email: `${userId}@example.com`
+    },
+    expiresAt,
+    idToken: `old-id-token-${userId}`,
+    refreshToken: `old-refresh-token-${userId}`,
+    urls: {
+      token: 'http://defra-id.auth/token',
+      logout: 'http://defra-id.auth/logout'
+    }
+  }
+})
+
+/**
+ * @param {string} sessionId
+ * @returns {Promise<string>}
+ */
+const sealCookie = (sessionId) =>
+  Iron.seal({ sessionId }, config.get('session.cookie.password'), Iron.defaults)
+
+describe('/auth/refresh - integration', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('should refresh token and redirect to returnTo on success', async ({
+    server,
+    msw
+  }) => {
+    const timerSpy = vi.spyOn(Metrics.prototype, 'timer')
+
+    msw.use(
+      ((jwtPayload) =>
+        http.post('http://defra-id.auth/token', async () =>
+          HttpResponse.json({
+            expires_in: 3600,
+            id_token: createFakeJwt(jwtPayload),
+            refresh_token: 'refreshed-new-token',
+            token_type: 'Bearer'
+          })
+        ))(defaultJwtPayload)
+    )
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const { sessionId, sessionData } = createExpiredSessionData(
+      'user-refresh',
+      expiresAt
+    )
+
+    sessionData.profile.enrolmentCount = 1
+    sessionData.profile.relationships = ['rel-123']
+    sessionData.profile.roles = ['role1']
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh?returnTo=%2Fsome-page',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/some-page')
+
+    const updatedSession = await server.app.cache.get(sessionId)
+    expect(updatedSession.refreshToken).toBe('refreshed-new-token')
+
+    expect(timerSpy).toHaveBeenCalledExactlyOnceWith(
+      'tokenRefreshDuration',
+      expect.any(Function),
+      { type: 'blocking' }
+    )
+  })
+
+  it('should redirect to /logged-out when refresh fails', async ({
+    server,
+    msw
+  }) => {
+    msw.use(
+      http.post('http://defra-id.auth/token', () =>
+        HttpResponse.json(
+          {
+            error: 'invalid_grant',
+            error_description: 'Refresh token expired'
+          },
+          { status: 400 }
+        )
+      )
+    )
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const { sessionId, sessionData } = createExpiredSessionData(
+      'user-refresh-fail',
+      expiresAt
+    )
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh?returnTo=%2Fsome-page',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/logged-out')
+
+    const removedSession = await server.app.cache.get(sessionId)
+    expect(removedSession).toBeNull()
+  })
+
+  it('should use / as default when returnTo is missing', async ({
+    server,
+    msw
+  }) => {
+    msw.use(
+      ((jwtPayload) =>
+        http.post('http://defra-id.auth/token', async () =>
+          HttpResponse.json({
+            expires_in: 3600,
+            id_token: createFakeJwt(jwtPayload),
+            refresh_token: 'refreshed-default',
+            token_type: 'Bearer'
+          })
+        ))(defaultJwtPayload)
+    )
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const { sessionId, sessionData } = createExpiredSessionData(
+      'user-no-return',
+      expiresAt
+    )
+
+    sessionData.profile.enrolmentCount = 1
+    sessionData.profile.relationships = ['rel-123']
+    sessionData.profile.roles = ['role1']
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/')
+  })
+
+  it('should reject absolute URL in returnTo', async ({ server, msw }) => {
+    msw.use(
+      ((jwtPayload) =>
+        http.post('http://defra-id.auth/token', async () =>
+          HttpResponse.json({
+            expires_in: 3600,
+            id_token: createFakeJwt(jwtPayload),
+            refresh_token: 'refreshed-safe',
+            token_type: 'Bearer'
+          })
+        ))(defaultJwtPayload)
+    )
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const { sessionId, sessionData } = createExpiredSessionData(
+      'user-open-redirect',
+      expiresAt
+    )
+
+    sessionData.profile.enrolmentCount = 1
+    sessionData.profile.relationships = ['rel-123']
+    sessionData.profile.roles = ['role1']
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh?returnTo=https://evil.com',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/')
+  })
+
+  it('should reject protocol-relative URL in returnTo', async ({
+    server,
+    msw
+  }) => {
+    msw.use(
+      ((jwtPayload) =>
+        http.post('http://defra-id.auth/token', async () =>
+          HttpResponse.json({
+            expires_in: 3600,
+            id_token: createFakeJwt(jwtPayload),
+            refresh_token: 'refreshed-safe-2',
+            token_type: 'Bearer'
+          })
+        ))(defaultJwtPayload)
+    )
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const { sessionId, sessionData } = createExpiredSessionData(
+      'user-proto-relative',
+      expiresAt
+    )
+
+    sessionData.profile.enrolmentCount = 1
+    sessionData.profile.relationships = ['rel-123']
+    sessionData.profile.roles = ['role1']
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh?returnTo=//evil.com',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/')
+  })
+
+  it('should skip refresh when idTokenRefreshInProgress is set and redirect to returnTo', async ({
+    server
+  }) => {
+    const timerSpy = vi.spyOn(Metrics.prototype, 'timer')
+
+    const expiresAt = addSeconds(new Date(), 5).toISOString()
+    const sessionId = 'test-session-in-progress'
+
+    const sessionData = {
+      profile: { id: 'user-in-progress', email: 'inprogress@example.com' },
+      expiresAt,
+      idToken: 'old-id-token-in-progress',
+      refreshToken: 'old-refresh-token-in-progress',
+      idTokenRefreshInProgress: true,
+      urls: {
+        token: 'http://defra-id.auth/token',
+        logout: 'http://defra-id.auth/logout'
+      }
+    }
+
+    await server.app.cache.set(sessionId, sessionData)
+    const sealedCookie = await sealCookie(sessionId)
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/auth/refresh?returnTo=%2Foriginal-page',
+      headers: {
+        cookie: `userSession=${sealedCookie}`
+      }
+    })
+
+    expect(response.statusCode).toBe(statusCodes.found)
+    expect(response.headers.location).toBe('/original-page')
+
+    // Session unchanged: refresh was skipped because it was already in progress
+    const unchangedSession = await server.app.cache.get(sessionId)
+    expect(unchangedSession.idToken).toBe('old-id-token-in-progress')
+    expect(unchangedSession.refreshToken).toBe('old-refresh-token-in-progress')
+
+    expect(timerSpy).toHaveBeenCalledExactlyOnceWith(
+      'tokenRefreshDuration',
+      expect.any(Function),
+      { type: 'blocking' }
+    )
+  })
+})

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -2,7 +2,8 @@ export const paths = Object.freeze({
   auth: Object.freeze({
     callback: '/auth/callback',
     logout: '/auth/logout',
-    organisation: '/auth/organisation'
+    organisation: '/auth/organisation',
+    refresh: '/auth/refresh'
   }),
   loggedOut: '/logged-out',
   start: '/start'


### PR DESCRIPTION
## Problem

The CDP 'epr-frontend - Average Response Time' alert fires in prod (~1405ms vs 1s threshold). The root cause is blocking token refresh: when a user's OIDC token has expired, the next request blocks for ~1400ms while the server round-trips to the Defra ID token endpoint. This inflates the average response time for normal page loads.

The response time alert is infrastructure-level (CDP platform). We cannot filter individual requests from it or adjust thresholds per-URL at source.

## How this helps

The slow OIDC round-trip currently happens **inline on the page request**, so it counts against that page's response time. This PR moves it to a **dedicated `/auth/refresh` URL**:

1. User requests `/some-page` with an expired token
2. Instead of blocking for ~1400ms, the server responds immediately with a **302 redirect** to `/auth/refresh?returnTo=%2Fsome-page` (~20ms)
3. `/auth/refresh` performs the slow token refresh (~1400ms)
4. `/auth/refresh` redirects back to `/some-page`, which now loads normally with a fresh token

The original page responds in ~20ms instead of ~1400ms. The slow OIDC call still happens, but on `/auth/refresh` — a distinct URL that can be excluded from the CDP alert query or given a higher threshold.

## Changes

- When a **GET** request hits an expired session (within 10 seconds of expiry), the session cookie `validate` function flags the request instead of calling `blockingRefresh` inline
- An `onPostAuth` server extension intercepts flagged requests and redirects to `/auth/refresh?returnTo=<original-url>`
- The new `/auth/refresh` endpoint performs the blocking token refresh, then redirects the user back to the original page
- **POST** requests still use inline blocking refresh to avoid losing the request body in a redirect
- The `returnTo` query parameter is validated to reject absolute and protocol-relative URLs (open redirect prevention)