### PR TITLE
PAE-000: Resolve Snyk vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "i18next-http-middleware": "3.9.2",
         "ioredis": "5.10.1",
         "jose": "6.2.2",
-        "lodash-es": "4.17.23",
+        "lodash-es": "4.18.1",
         "nunjucks": "3.2.4",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
@@ -2646,9 +2646,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
+      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -13669,9 +13669,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -19677,9 +19677,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19704,7 +19704,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "i18next-http-middleware": "3.9.2",
     "ioredis": "5.10.1",
     "jose": "6.2.2",
-    "lodash-es": "4.17.23",
+    "lodash-es": "4.18.1",
     "nunjucks": "3.2.4",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
@@ -147,6 +147,7 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
+    "@hapi/content": "6.0.1",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## What

Automated Snyk vulnerability fixes for open-source dependency scan findings.

## Open-source dependency vulnerabilities

| Package | Old Version | New Version | Severity | Vulnerability |
|---------|-------------|-------------|----------|---------------|
| lodash-es | 4.17.23 | 4.18.1 | Medium | Prototype Pollution (SNYK-JS-LODASHES-15869621) |
| lodash-es | 4.17.23 | 4.18.1 | High | Arbitrary Code Injection (SNYK-JS-LODASHES-15869627) |
| @hapi/content | 6.0.0 | 6.0.1 (override) | High | ReDoS (SNYK-JS-HAPICONTENT-15907598) |
| vite | 8.0.0 | 8.0.5 (audit fix) | High | Path Traversal, fs.deny bypass, WebSocket file read |

## Code analysis findings

All 6 findings were triaged as false positives or test-only patterns:

| File | Issue Type | Severity | Status |
|------|-----------|----------|--------|
| src/server/reports/helpers/create-data-page-controllers.js:144 | Open Redirect | Medium | False positive — `action` is Joi-validated to `continue\|save` only |
| src/server/reports/helpers/create-data-page-controllers.js:210 | Open Redirect | Medium | False positive — same Joi validation |
| src/server/reports/reprocessor/tonnes-not-recycled-controller.js:63 | Open Redirect | Medium | False positive — same Joi validation |
| src/server/auth/helpers/session-cookie.test.js:12 | Insecure JWT Verification | Low | Test file — intentional decode without verification |
| src/server/auth/plugins/defra-id.test.js:46 | Insecure JWT Verification | Low | Test file — intentional decode without verification |
| src/server/auth/plugins/defra-id.test.js:129 | Hardcoded Password | Low | Test file — test fixture data |

## Container image vulnerabilities

7 vulnerabilities found in global npm@11.11.0 within the base image `defradigital/node:3.0.5-node24.14.1` (minimatch, brace-expansion, picomatch, tar). This is already the latest available Defra base image. These packages are only used by npm during `npm ci` at build time and are not present or exploitable at runtime (the production image runs `node .`).

## Verification

- `snyk test` — 0 remaining dependency issues (was 3)
- `snyk code test` — 6 findings acknowledged (3 false positive, 3 test-only)
- `snyk container test` — 7 findings in base image (no newer image available)
- `npm test` — all 1782 tests pass across 140 test files