### PR TITLE
PAE-1316: Add ORS help text on create report page

### DIFF
--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -939,6 +939,21 @@ describe('#detailReportsController', () => {
         expect(supplierTable.textContent).toContain('Baler')
         expect(supplierTable.textContent).toContain('42.21')
       })
+
+      it('should not display ORS help text', async ({ server }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(
+          queryByText(body, /upload your summary logs again for this period/)
+        ).toBeNull()
+      })
     })
 
     describe('for registered-only exporter with data', () => {

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -4,7 +4,13 @@ import { fetchRegistrationAndAccreditation } from '#server/common/helpers/organi
 import { fetchReportDetail } from '#server/reports/helpers/fetch-report-detail.js'
 import { it } from '#vite/fixtures/server.js'
 import Boom from '@hapi/boom'
-import { getAllByRole, getByRole, queryByRole } from '@testing-library/dom'
+import {
+  getAllByRole,
+  getByRole,
+  getByText,
+  queryByRole,
+  queryByText
+} from '@testing-library/dom'
 import { JSDOM } from 'jsdom'
 import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest'
 
@@ -744,6 +750,21 @@ describe('#detailReportsController', () => {
         expect(button).toBeDefined()
       })
 
+      it('should not display ORS help text', async ({ server }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: detailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(
+          queryByText(body, /upload your summary logs again for this period/)
+        ).toBeNull()
+      })
+
       it('should have a POST form for the Use this data button', async ({
         server
       }) => {
@@ -1013,6 +1034,24 @@ describe('#detailReportsController', () => {
         const { body } = dom.window.document
 
         expect(body.textContent).toContain('11.47')
+      })
+
+      it('should display ORS help text', async ({ server }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(
+          getByText(body, /upload your summary logs again for this period/)
+        ).toBeDefined()
+        expect(
+          getByText(body, /please contact your regulator before you create/)
+        ).toBeDefined()
       })
 
       it('should display overseas sites in table', async ({ server }) => {
@@ -1316,6 +1355,24 @@ describe('#detailReportsController', () => {
             level: 3
           })
         ).toBeNull()
+      })
+
+      it('should display ORS help text', async ({ server }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(
+          getByText(body, /upload your summary logs again for this period/)
+        ).toBeDefined()
+        expect(
+          getByText(body, /please contact your regulator before you create/)
+        ).toBeDefined()
       })
 
       it('should display overseas site OSR IDs in table', async ({

--- a/src/server/reports/detail.njk
+++ b/src/server/reports/detail.njk
@@ -75,6 +75,11 @@
         <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:totalTonnageExported") }}</p>
         <p class="govuk-heading-l">{{ wasteExported.totalTonnage | formatTonnage }}</p>
 
+        <div class="govuk-inset-text">
+          <p class="govuk-body">{{ localise("reports:orsHelpLine1") }}</p>
+          <p class="govuk-body">{{ localise("reports:orsHelpLine2") }}</p>
+        </div>
+
         {% if wasteExported.overseasSiteDetailRows | length > 0 %}
           <h3 class="govuk-heading-m">{{ localise("reports:overseasSitesHeading") }}</h3>
           {{ govukTable({

--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -93,6 +93,8 @@
   "noteSummaryRevenueLabel": "Enter total revenue of {{noteTypePlural}}, excluding VAT",
   "noteSummarySave": "Save and come back later",
   "noteTypeSectionHeading": "{{noteTypePlural}}",
+  "orsHelpLine1": "If any of your ORS data is missing, upload your summary logs again for this period to fix the problem.",
+  "orsHelpLine2": "If this does not fix the problem, please contact your regulator before you create your report.",
   "osrIdColumn": "Approved overseas reprocessor ID",
   "overseasSitesHeading": "Overseas reprocessing sites",
   "overviewIntro": "The following is an overview of your summary log data for {{ periodLabel }}. Only the data that will appear in your report is shown here.",


### PR DESCRIPTION
Ticket: [PAE-1316](https://eaflood.atlassian.net/browse/PAE-1316)
## Summary

- Add temporary help text above the ORS section on the create report page for exporter registrations (both registered-only and accredited)
- Help text advises users to re-upload summary logs if ORS data is missing, or contact their regulator if the problem persists
- Reprocessor registrations are unaffected

## Why

ORS validation is built but gated behind a feature flag while we wait for regulator reference data (PAE-1312). Until that lands, exporters can submit summary logs containing ORS IDs we cannot resolve, which show up as blank-named rows in their reports. This copy tells them what to do when they see that situation. This is a Day 1 fix for the April 13th release — the copy is temporary and can be removed once ORS validation is enabled.

## Changes

- `src/server/reports/detail.njk` — inset text block with two paragraphs added inside the exporter-only section, between total tonnage exported and the overseas sites table
- `src/server/reports/en.json` — two new translation keys (`orsHelpLine1`, `orsHelpLine2`) with content-designer-approved copy
- `src/server/reports/detail-controller.test.js` — four new tests: positive assertions for registered-only and accredited exporters, negative assertions for registered-only and accredited reprocessors

[PAE-1316]: https://eaflood.atlassian.net/browse/PAE-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ