### PR TITLE
PAE-1317: Add summary log warning on check your answers page

### DIFF
--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -734,9 +734,7 @@ describe('#checkController', () => {
           )
         })
 
-        it('should display summary log warning before create button', async ({
-          server
-        }) => {
+        it('should display summary log warning', async ({ server }) => {
           const { result } = await server.inject({
             method: 'GET',
             url: baseUrl,
@@ -749,10 +747,6 @@ describe('#checkController', () => {
           getByText(
             body,
             /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
-          )
-          getByText(
-            body,
-            /You can delete this report before it's submitted and start again if you need to update your records/
           )
         })
 

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -4,7 +4,7 @@ import { fetchRegistrationAndAccreditation } from '#server/common/helpers/organi
 import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
 import { fetchReportDetail } from '#server/reports/helpers/fetch-report-detail.js'
 import { it } from '#vite/fixtures/server.js'
-import { getByRole, queryByRole } from '@testing-library/dom'
+import { getByRole, getByText, queryByRole } from '@testing-library/dom'
 import { JSDOM } from 'jsdom'
 import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest'
 
@@ -734,6 +734,28 @@ describe('#checkController', () => {
           )
         })
 
+        it('should display summary log warning before create button', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth
+          })
+
+          const dom = new JSDOM(result)
+          const { body } = dom.window.document
+
+          getByText(
+            body,
+            /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
+          )
+          getByText(
+            body,
+            /You can delete this report before it's submitted and start again if you need to update your records/
+          )
+        })
+
         it('should display back link to supporting information page', async ({
           server
         }) => {
@@ -990,6 +1012,24 @@ describe('#checkController', () => {
 
           expect(headerSummaryList?.textContent).toContain('Site')
           expect(headerSummaryList?.textContent).toContain('North Road')
+        })
+
+        it('should display summary log warning for reprocessor', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth
+          })
+
+          const dom = new JSDOM(result)
+          const { body } = dom.window.document
+
+          getByText(
+            body,
+            /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
+          )
         })
 
         it('should display destination table with 4 columns', async ({

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -744,10 +744,12 @@ describe('#checkController', () => {
           const dom = new JSDOM(result)
           const { body } = dom.window.document
 
-          getByText(
-            body,
-            /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
-          )
+          expect(
+            getByText(
+              body,
+              /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
+            )
+          ).toBeDefined()
         })
 
         it('should display back link to supporting information page', async ({
@@ -1020,10 +1022,12 @@ describe('#checkController', () => {
           const dom = new JSDOM(result)
           const { body } = dom.window.document
 
-          getByText(
-            body,
-            /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
-          )
+          expect(
+            getByText(
+              body,
+              /Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report/
+            )
+          ).toBeDefined()
         })
 
         it('should display destination table with 4 columns', async ({

--- a/src/server/reports/check-your-answers.njk
+++ b/src/server/reports/check-your-answers.njk
@@ -229,6 +229,10 @@
         ]
       }) }}
 
+      {{ govukInsetText({
+        text: localise("reports:checkSummaryLogWarning")
+      }) }}
+
       <form method="POST" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}" />
         <input type="hidden" name="version" value="{{ version }}" />

--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -18,6 +18,7 @@
   "checkRevenueLabel": "Total revenue of {{noteTypePlural}}",
   "checkSummaryLogDataGuidance": "If any information in this section is incorrect, cancel this report, upload an updated summary log and create a new report.",
   "checkSummaryLogDataHeading": "Summary log data",
+  "checkSummaryLogWarning": "Once this report is created, any future summary log uploads that cover activity in this period will not be counted in this report. You can delete this report before it's submitted and start again if you need to update your records.",
   "checkSupportingInformationHeading": "Supporting information",
   "checkTonnageNotRecycledLabel": "Total tonnage of packaging waste received but not recycled",
   "checkTonnageRecycledLabel": "Total tonnage of packaging waste recycled",


### PR DESCRIPTION
## Summary

Adds inset text on the "Check your answers" page warning users that a created report is a snapshot — future summary log uploads covering the same period will not be reflected in it. The copy advises users they can delete and recreate the report before submission if their records change.

- Applies to all report types (reprocessor and exporter, monthly and quarterly)
- Uses `govukInsetText`, placed immediately above the "Create report" button
- Copy matches the Jira ticket exactly

Jira: [PAE-1317](https://eaflood.atlassian.net/browse/PAE-1317)

[PAE-1317]: https://eaflood.atlassian.net/browse/PAE-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ