### PR TITLE
PAE-1323: Rename ORS column header to drop Approved qualifier

### DIFF
--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -501,7 +501,7 @@ describe('#checkController', () => {
           )
           expect(headerTexts).toStrictEqual([
             'Site name',
-            'Approved overseas reprocessor ID',
+            'Overseas reprocessor ID',
             'Country'
           ])
         })
@@ -1529,7 +1529,7 @@ describe('#checkController', () => {
           )
           expect(headerTexts).toStrictEqual([
             'Site name',
-            'Approved overseas reprocessor ID',
+            'Overseas reprocessor ID',
             'Country',
             'Approved'
           ])

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -1188,7 +1188,7 @@ describe('#detailReportsController', () => {
           const headers = t.querySelector('thead')?.textContent ?? ''
           return (
             headers.includes('Overseas reprocessor ID') &&
-            !headers.includes('Approved overseas reprocessor ID')
+            !headers.includes('Site name')
           )
         })
 

--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -97,7 +97,7 @@
   "noteTypeSectionHeading": "{{noteTypePlural}}",
   "orsHelpLine1": "If any of your ORS data is missing, upload your summary logs again for this period to fix the problem.",
   "orsHelpLine2": "If this does not fix the problem, please contact your regulator before you create your report.",
-  "osrIdColumn": "Approved overseas reprocessor ID",
+  "osrIdColumn": "Overseas reprocessor ID",
   "overseasSitesHeading": "Overseas reprocessing sites",
   "overviewIntro": "The following is an overview of your summary log data for {{ periodLabel }}. Only the data that will appear in your report is shown here.",
   "pageTitle": "Reports: {{ material }}",

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -433,7 +433,7 @@ describe('#submitController', () => {
           const body = await getBody(server)
 
           expect(body.textContent).toContain('Site name')
-          expect(body.textContent).toContain('Approved overseas reprocessor ID')
+          expect(body.textContent).toContain('Overseas reprocessor ID')
         })
 
         it('should display overseas sites with tonnage and OSR ID', async ({

--- a/src/server/reports/view-controller.test.js
+++ b/src/server/reports/view-controller.test.js
@@ -900,9 +900,7 @@ describe('#viewController', () => {
             const tableHeader = section.querySelector('table thead')
 
             expect(tableHeader.textContent).toContain('Site name')
-            expect(tableHeader.textContent).toContain(
-              'Approved overseas reprocessor ID'
-            )
+            expect(tableHeader.textContent).toContain('Overseas reprocessor ID')
             expect(tableHeader.textContent).toContain('Country')
           }
         )


### PR DESCRIPTION
Ticket: [PAE-1323](https://eaflood.atlassian.net/browse/PAE-1323)

## Summary

- Renames the Table 1 ORS ID column header from "Approved overseas reprocessor ID" to "Overseas reprocessor ID", removing the misleading "Approved" qualifier per the AC on PAE-1323
- Updates test assertions across detail, check, view, and submit controllers

[PAE-1323]: https://eaflood.atlassian.net/browse/PAE-1323