### PR TITLE
PAE-1326: Update summary log hint text on detail page per journey type

### DIFF
--- a/src/server/reports/detail-controller.js
+++ b/src/server/reports/detail-controller.js
@@ -47,6 +47,47 @@ function buildWasteExported(exportActivity, isExporter, isAccreditedExporter) {
 }
 
 /**
+ * @param {boolean} isAccreditedExporter
+ * @param {boolean} isExporter
+ * @returns {string}
+ */
+function getWasteSentOnIntroKey(isAccreditedExporter, isExporter) {
+  if (isAccreditedExporter) {
+    return 'reports:wasteSentOnIntroAccreditedExporter'
+  }
+  if (isExporter) {
+    return 'reports:wasteSentOnIntroExporter'
+  }
+  return 'reports:wasteSentOnIntroReprocessor'
+}
+
+/**
+ * @param {boolean} isAccreditedExporter
+ * @param {boolean} isExporter
+ * @param {(key: string) => string} localise
+ * @returns {object}
+ */
+function buildSectionIntros(isAccreditedExporter, isExporter, localise) {
+  return {
+    wasteSentOnIntro: localise(
+      getWasteSentOnIntroKey(isAccreditedExporter, isExporter)
+    ),
+    wasteReceivedForExportIntro: isAccreditedExporter
+      ? localise('reports:wasteReceivedForExportIntro')
+      : localise('reports:wasteReceivedForExportIntroRegOnly'),
+    wasteExportedIntro: isAccreditedExporter
+      ? localise('reports:wasteExportedIntro')
+      : localise('reports:wasteExportedIntroRegOnly'),
+    tonnageReceivedNotExportedIntro: isAccreditedExporter
+      ? localise('reports:tonnageReceivedNotExportedIntro')
+      : localise('reports:tonnageReceivedNotExportedIntroRegOnly'),
+    tonnageRefusedOrStoppedIntro: isAccreditedExporter
+      ? localise('reports:tonnageRefusedOrStoppedIntro')
+      : localise('reports:tonnageRefusedOrStoppedIntroRegOnly')
+  }
+}
+
+/**
  * @param {{ organisationId: string, registrationId: string }} ids
  * @param {object} registration
  * @param {object | undefined} accreditation
@@ -115,23 +156,7 @@ function buildViewData(
       toOtherSites: wasteSent.tonnageSentToAnotherSite,
       destinationRows: buildDestinationRows(wasteSent.finalDestinations)
     },
-    wasteSentOnIntro: isAccreditedExporter
-      ? localise('reports:wasteSentOnIntroAccreditedExporter')
-      : isExporter
-        ? localise('reports:wasteSentOnIntroExporter')
-        : localise('reports:wasteSentOnIntroReprocessor'),
-    wasteReceivedForExportIntro: isAccreditedExporter
-      ? localise('reports:wasteReceivedForExportIntro')
-      : localise('reports:wasteReceivedForExportIntroRegOnly'),
-    wasteExportedIntro: isAccreditedExporter
-      ? localise('reports:wasteExportedIntro')
-      : localise('reports:wasteExportedIntroRegOnly'),
-    tonnageReceivedNotExportedIntro: isAccreditedExporter
-      ? localise('reports:tonnageReceivedNotExportedIntro')
-      : localise('reports:tonnageReceivedNotExportedIntroRegOnly'),
-    tonnageRefusedOrStoppedIntro: isAccreditedExporter
-      ? localise('reports:tonnageRefusedOrStoppedIntro')
-      : localise('reports:tonnageRefusedOrStoppedIntroRegOnly')
+    ...buildSectionIntros(isAccreditedExporter, isExporter, localise)
   }
 }
 

--- a/src/server/reports/detail-controller.js
+++ b/src/server/reports/detail-controller.js
@@ -114,7 +114,24 @@ function buildViewData(
       toExporters: wasteSent.tonnageSentToExporter,
       toOtherSites: wasteSent.tonnageSentToAnotherSite,
       destinationRows: buildDestinationRows(wasteSent.finalDestinations)
-    }
+    },
+    wasteSentOnIntro: isAccreditedExporter
+      ? localise('reports:wasteSentOnIntroAccreditedExporter')
+      : isExporter
+        ? localise('reports:wasteSentOnIntroExporter')
+        : localise('reports:wasteSentOnIntroReprocessor'),
+    wasteReceivedForExportIntro: isAccreditedExporter
+      ? localise('reports:wasteReceivedForExportIntro')
+      : localise('reports:wasteReceivedForExportIntroRegOnly'),
+    wasteExportedIntro: isAccreditedExporter
+      ? localise('reports:wasteExportedIntro')
+      : localise('reports:wasteExportedIntroRegOnly'),
+    tonnageReceivedNotExportedIntro: isAccreditedExporter
+      ? localise('reports:tonnageReceivedNotExportedIntro')
+      : localise('reports:tonnageReceivedNotExportedIntroRegOnly'),
+    tonnageRefusedOrStoppedIntro: isAccreditedExporter
+      ? localise('reports:tonnageRefusedOrStoppedIntro')
+      : localise('reports:tonnageRefusedOrStoppedIntroRegOnly')
   }
 }
 

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -787,6 +787,23 @@ describe('#detailReportsController', () => {
         expect(form).not.toBeNull()
         expect(form?.querySelector('input[name="crumb"]')).not.toBeNull()
       })
+
+      it('should display section 2 intro text for waste sent on', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: detailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 2 of your summary log'
+        )
+      })
     })
 
     describe('when no records match the period', () => {
@@ -959,6 +976,23 @@ describe('#detailReportsController', () => {
           queryByText(body, /upload your summary logs again for this period/)
         ).toBeNull()
       })
+
+      it('should display section 2 intro text for waste sent on', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 2 of your summary log'
+        )
+      })
     })
 
     describe('for registered-only exporter with data', () => {
@@ -1125,6 +1159,91 @@ describe('#detailReportsController', () => {
 
         expect(body.textContent).not.toContain(
           'Overseas reprocessor IDs that have not been logged'
+        )
+      })
+
+      it('should display section 1 intro text for waste received for export', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'The data for waste received comes from section 1 of your summary log'
+        )
+      })
+
+      it('should display section 2 intro text for waste exported for recycling', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 2 of your summary log'
+        )
+      })
+
+      it('should display section 1 intro text for tonnage received not exported', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 1 of your summary log'
+        )
+      })
+
+      it('should display section 2 intro text for tonnage refused or stopped', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 2 of your summary log'
+        )
+      })
+
+      it('should display section 4 intro text for waste sent on', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: exporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 4 of your summary log'
         )
       })
     })
@@ -1472,6 +1591,91 @@ describe('#detailReportsController', () => {
 
         expect(getByText(rows[0], 'Yes')).toBeDefined()
         expect(getByText(rows[1], 'No')).toBeDefined()
+      })
+
+      it('should display sections 1 and 2 intro text for waste received for export', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'The data for waste received comes from sections 1 and 2 of your summary log.'
+        )
+      })
+
+      it('should display sections 1 and 2 intro text for waste exported for recycling', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from sections 1 and 2 of your summary log.'
+        )
+      })
+
+      it('should display section 1 intro text for tonnage received not exported', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 1 of your summary log.'
+        )
+      })
+
+      it('should display sections 1 and 2 intro text for tonnage refused or stopped', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'The data comes from sections 1 and 2 of your summary log.'
+        )
+      })
+
+      it('should display section 4 and 5 intro text for waste sent on', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: accreditedExporterDetailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain(
+          'This data comes from section 4 and 5 of your summary log'
+        )
       })
     })
 

--- a/src/server/reports/detail.njk
+++ b/src/server/reports/detail.njk
@@ -49,7 +49,7 @@
 
       <h2 class="govuk-heading-l">{{ wasteReceivedHeading }}</h2>
       {% if isExporter %}
-        <p class="govuk-body">{{ localise("reports:wasteReceivedForExportIntro") }}</p>
+        <p class="govuk-body">{{ wasteReceivedForExportIntro }}</p>
       {% else %}
         <p class="govuk-body">{{ localise("reports:wasteReceivedIntro") }}</p>
       {% endif %}
@@ -71,7 +71,7 @@
 
       {% if isExporter %}
         <h2 class="govuk-heading-l">{{ localise("reports:wasteExportedHeading") }}</h2>
-        <p class="govuk-body">{{ localise("reports:wasteExportedIntro") }}</p>
+        <p class="govuk-body">{{ wasteExportedIntro }}</p>
 
         <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:totalTonnageExported") }}</p>
         <p class="govuk-heading-l">{{ wasteExported.totalTonnage | formatTonnage }}</p>
@@ -104,7 +104,7 @@
         }) }}
 
         <h2 class="govuk-heading-l">{{ localise("reports:tonnageReceivedNotExportedHeading") }}</h2>
-        <p class="govuk-body">{{ localise("reports:tonnageReceivedNotExportedIntro") }}</p>
+        <p class="govuk-body">{{ tonnageReceivedNotExportedIntro }}</p>
 
         <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:tonnageReceivedNotExportedLabel") }}</p>
         <p class="govuk-heading-l">{{ wasteExported.tonnageReceivedNotExported | formatTonnage }}</p>
@@ -112,7 +112,7 @@
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
         <h2 class="govuk-heading-l">{{ localise("reports:tonnageRefusedOrStoppedHeading") }}</h2>
-        <p class="govuk-body">{{ localise("reports:tonnageRefusedOrStoppedIntro") }}</p>
+        <p class="govuk-body">{{ tonnageRefusedOrStoppedIntro }}</p>
 
         <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:tonnageRefusedOrStoppedLabel") }}</p>
         <p class="govuk-heading-l">{{ wasteExported.tonnageRefusedOrStopped | formatTonnage }}</p>
@@ -127,7 +127,7 @@
       {% endif %}
 
       <h2 class="govuk-heading-l">{{ localise("reports:wasteSentOnHeading") }}</h2>
-      <p class="govuk-body">{{ localise("reports:wasteSentOnIntro") }}</p>
+      <p class="govuk-body">{{ wasteSentOnIntro }}</p>
 
       <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:totalTonnageSentOn") }}</p>
       <p class="govuk-heading-l">{{ wasteSentOn.totalTonnage | formatTonnage }}</p>

--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -173,6 +173,7 @@
   "tonnageReceivedColumn": "Tonnage received",
   "tonnageReceivedNotExportedHeading": "Packaging waste received but not exported",
   "tonnageReceivedNotExportedIntro": "This data comes from section 1 of your summary log.",
+  "tonnageReceivedNotExportedIntroRegOnly": "This data comes from section 1 of your summary log",
   "tonnageReceivedNotExportedLabel": "Total tonnage not exported",
   "tonnageRecycledCaption": "Create report",
   "tonnageRecycledContinue": "Continue",
@@ -187,6 +188,7 @@
   "tonnageRefusedLabel": "Total tonnage refused",
   "tonnageRefusedOrStoppedHeading": "Packaging waste refused or stopped during export",
   "tonnageRefusedOrStoppedIntro": "The data comes from sections 1 and 2 of your summary log.",
+  "tonnageRefusedOrStoppedIntroRegOnly": "This data comes from section 2 of your summary log",
   "tonnageRefusedOrStoppedLabel": "Total tonnage refused or stopped",
   "tonnageRepatriatedLabel": "Total tonnage repatriated",
   "tonnageSentOnColumn": "Tonnage sent on",
@@ -229,9 +231,13 @@
   },
   "wasteExportedHeading": "Packaging waste exported for recycling",
   "wasteExportedIntro": "This data comes from sections 1 and 2 of your summary log.",
+  "wasteExportedIntroRegOnly": "This data comes from section 2 of your summary log",
   "wasteReceivedForExportIntro": "The data for waste received comes from sections 1 and 2 of your summary log.",
+  "wasteReceivedForExportIntroRegOnly": "The data for waste received comes from section 1 of your summary log",
   "wasteReceivedHeading": "Packaging waste received for {{wasteActionGerund}}",
   "wasteReceivedIntro": "This data comes from sections 1 and 2 of your summary log.",
   "wasteSentOnHeading": "Packaging waste sent on",
-  "wasteSentOnIntro": "This data comes from sections 5 and 6 of your summary log."
+  "wasteSentOnIntroAccreditedExporter": "This data comes from section 4 and 5 of your summary log",
+  "wasteSentOnIntroExporter": "This data comes from section 4 of your summary log",
+  "wasteSentOnIntroReprocessor": "This data comes from section 2 of your summary log"
 }


### PR DESCRIPTION
Ticket: [PAE-1326](https://eaflood.atlassian.net/browse/PAE-1326)
- Add journey-specific i18n keys for section intro text across reprocessor, reg-only exporter, and accredited exporter journeys
- Pre-compute five intro strings in the detail controller based on journey type rather than resolving them in the template
- Replace hardcoded localise() calls in detail.njk with pre-computed controller values
- Add tests covering intro text for all four journey types (reprocessor, accredited reprocessor, reg-only exporter, accredited exporter)

[PAE-1326]: https://eaflood.atlassian.net/browse/PAE-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ