### PR TITLE
PAE-1323: Add both ORS tables and Approved column to submit page

### DIFF
--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -13,6 +13,7 @@ import {
   buildDestinationDetailRows,
   buildOverseasSiteRows,
   buildSupplierDetailRows,
+  buildUnapprovedOverseasSiteRows,
   getTotalTonnageSentOn
 } from './helpers/build-table-rows.js'
 import { fetchReportDetail } from './helpers/fetch-report-detail.js'
@@ -54,9 +55,10 @@ const defaultExportActivity = {
 /**
  * @param {object|null|undefined} exportActivity
  * @param {boolean} isExporter
+ * @param {boolean} isAccreditedExporter
  * @returns {object|null}
  */
-function buildWasteExported(exportActivity, isExporter) {
+function buildWasteExported(exportActivity, isExporter, isAccreditedExporter) {
   if (!isExporter) {
     return null
   }
@@ -64,7 +66,12 @@ function buildWasteExported(exportActivity, isExporter) {
   const activity = exportActivity ?? defaultExportActivity
   return {
     totalTonnage: formatTonnage(activity.totalTonnageExported),
-    overseasSiteRows: buildOverseasSiteRows(activity.overseasSites),
+    overseasSiteRows: buildOverseasSiteRows(activity.overseasSites, {
+      showApprovalColumn: isAccreditedExporter
+    }),
+    unapprovedOverseasSiteRows: buildUnapprovedOverseasSiteRows(
+      activity.unapprovedOverseasSites ?? []
+    ),
     ...formatExportTonnages(activity)
   }
 }
@@ -190,6 +197,7 @@ function buildViewData({
   const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
   const { recyclingActivity, exportActivity, wasteSent } = reportDetail
   const isExporter = isExporterRegistration(registration)
+  const isAccreditedExporter = isExporter && !!accreditation
   const { noteTypePlural, wasteActionGerund } =
     getNoteTypeDisplayNames(registration)
 
@@ -211,6 +219,7 @@ function buildViewData({
     isAccredited: !!accreditation,
     isReprocessor: isReprocessorRegistration(registration),
     isExporter,
+    showApprovalColumn: isAccreditedExporter,
     backUrl: localiseUrl(reportsUrl),
 
     // Inset text
@@ -234,7 +243,11 @@ function buildViewData({
     },
 
     // Waste exported (exporters only — always show section with defaults)
-    wasteExported: buildWasteExported(exportActivity, isExporter),
+    wasteExported: buildWasteExported(
+      exportActivity,
+      isExporter,
+      isAccreditedExporter
+    ),
 
     // Waste sent on
     wasteSentOn: buildWasteSentOnViewData(wasteSent),

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -178,6 +178,24 @@ function buildPageLabels({
 }
 
 /**
+ * @param {ReportDetailResponse['recyclingActivity']} recyclingActivity
+ * @returns {{ totalTonnage: string, supplierDetailRows: Array<Array<{text: string}>> }}
+ */
+const buildWasteReceivedViewData = (recyclingActivity) => ({
+  totalTonnage: formatTonnage(recyclingActivity.totalTonnageReceived),
+  supplierDetailRows: buildSupplierDetailRows(recyclingActivity.suppliers)
+})
+
+/**
+ * @param {ReportDetailResponse['recyclingActivity']} recyclingActivity
+ * @returns {{ tonnageRecycled: string, tonnageNotRecycled: string }}
+ */
+const buildRecyclingActivityViewData = (recyclingActivity) => ({
+  tonnageRecycled: formatTonnage(recyclingActivity.tonnageRecycled),
+  tonnageNotRecycled: formatTonnage(recyclingActivity.tonnageNotRecycled)
+})
+
+/**
  * @param {{ registration: object, accreditation: object | undefined, reportDetail: ReportDetailResponse, organisationId: string, registrationId: string, year: number, cadence: string, period: number, localise: (key: string, params?: Record<string, string>) => string, localiseUrl: (url: string) => string }} params
  * @returns {object}
  */
@@ -237,10 +255,7 @@ function buildViewData({
     material,
 
     // Waste received
-    wasteReceived: {
-      totalTonnage: formatTonnage(recyclingActivity.totalTonnageReceived),
-      supplierDetailRows: buildSupplierDetailRows(recyclingActivity.suppliers)
-    },
+    wasteReceived: buildWasteReceivedViewData(recyclingActivity),
 
     // Waste exported (exporters only — always show section with defaults)
     wasteExported: buildWasteExported(
@@ -261,10 +276,7 @@ function buildViewData({
     },
 
     // Recycling activity
-    recyclingActivity: {
-      tonnageRecycled: formatTonnage(recyclingActivity.tonnageRecycled),
-      tonnageNotRecycled: formatTonnage(recyclingActivity.tonnageNotRecycled)
-    },
+    recyclingActivity: buildRecyclingActivityViewData(recyclingActivity),
 
     // Supporting information
     supportingInformation:

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -8,7 +8,7 @@ import {
 import { getCsrfToken } from '#server/common/test-helpers/csrf-helper.js'
 import { fetchReportDetail } from '#server/reports/helpers/fetch-report-detail.js'
 import { it } from '#vite/fixtures/server.js'
-import { getByRole, queryByRole } from '@testing-library/dom'
+import { getByRole, getByText, queryByRole } from '@testing-library/dom'
 import { JSDOM } from 'jsdom'
 import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest'
 
@@ -105,9 +105,20 @@ const exporterReportDetail = {
   exportActivity: {
     totalTonnageExported: 50,
     overseasSites: [
-      { siteName: 'Brussels Recycling', orsId: 'OSR-001', country: 'Belgium' },
-      { siteName: 'RecyclePlast SA', orsId: 'OSR-096', country: 'France' }
+      {
+        siteName: 'Brussels Recycling',
+        orsId: 'OSR-001',
+        country: 'Belgium',
+        approved: false
+      },
+      {
+        siteName: 'RecyclePlast SA',
+        orsId: 'OSR-096',
+        country: 'France',
+        approved: false
+      }
     ],
+    unapprovedOverseasSites: [{ orsId: 'OSR-999', tonnageExported: 12.5 }],
     tonnageReceivedNotExported: 12.5,
     totalTonnageRefusedOrStopped: 10.8,
     tonnageRefusedAtDestination: 2.5,
@@ -216,6 +227,17 @@ const accreditedExporterRegistration = {
 const accreditedExporterReportDetail = {
   ...exporterReportDetail,
   operatorCategory: 'EXPORTER_ACCREDITED',
+  exportActivity: {
+    ...exporterReportDetail.exportActivity,
+    overseasSites: [
+      {
+        siteName: 'Brussels Recycling',
+        orsId: 'OSR-001',
+        country: 'Belgium',
+        approved: true
+      }
+    ]
+  },
   prn: {
     averagePricePerTonne: 200,
     freeTonnage: 10,
@@ -445,6 +467,65 @@ describe('#submitController', () => {
           expect(body.textContent).toContain('30')
           expect(body.textContent).toContain('OSR-001')
           expect(body.textContent).toContain('RecyclePlast SA')
+        })
+
+        it('should not display Approved column header for non-accredited exporter', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          const tables = body.querySelectorAll('.govuk-table')
+          const overseasSiteTable = Array.from(tables).find((table) =>
+            table.textContent?.includes('Brussels Recycling')
+          )
+          const headers = overseasSiteTable?.querySelectorAll('th')
+          const headerTexts = Array.from(headers).map((h) =>
+            h.textContent?.trim()
+          )
+
+          expect(headerTexts).not.toContain('Approved')
+        })
+
+        it('should display unapproved overseas sites heading', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          expect(
+            getByRole(body, 'heading', {
+              name: /Overseas reprocessor IDs that have not been logged/,
+              level: 3
+            })
+          ).toBeDefined()
+        })
+
+        it('should display unapproved overseas sites intro text', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          expect(
+            getByText(
+              body,
+              /These overseas reprocessor IDs were in your summary log/
+            )
+          ).toBeDefined()
+        })
+
+        it('should display unapproved ORS ID in table', async ({ server }) => {
+          const body = await getBody(server)
+
+          const tables = body.querySelectorAll('.govuk-table')
+          const unapprovedTable = Array.from(tables).find((table) =>
+            table.textContent?.includes('OSR-999')
+          )
+
+          expect(unapprovedTable).not.toBeNull()
+          const headers = unapprovedTable?.querySelectorAll('th')
+          const headerTexts = Array.from(headers).map((h) =>
+            h.textContent?.trim()
+          )
+          expect(headerTexts).toStrictEqual(['Overseas reprocessor ID'])
         })
 
         // Received but not exported section
@@ -767,6 +848,43 @@ describe('#submitController', () => {
           vi.mocked(fetchReportDetail).mockResolvedValue(
             accreditedExporterReportDetail
           )
+        })
+
+        it('should display Approved column header in overseas sites table', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          const tables = body.querySelectorAll('.govuk-table')
+          const overseasSiteTable = Array.from(tables).find((table) =>
+            table.textContent?.includes('Brussels Recycling')
+          )
+          const headers = overseasSiteTable?.querySelectorAll('th')
+          const headerTexts = Array.from(headers).map((h) =>
+            h.textContent?.trim()
+          )
+
+          expect(headerTexts).toStrictEqual([
+            'Site name',
+            'Overseas reprocessor ID',
+            'Country',
+            'Approved'
+          ])
+        })
+
+        it('should display approval status for approved overseas site', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          const tables = body.querySelectorAll('.govuk-table')
+          const overseasSiteTable = Array.from(tables).find((table) =>
+            table.textContent?.includes('Brussels Recycling')
+          )
+          const cells = overseasSiteTable?.querySelectorAll('td')
+          const lastCell = cells?.[cells.length - 1]
+
+          expect(lastCell?.textContent?.trim()).toBe('Yes')
         })
 
         it('should not display recycling activity section', async ({

--- a/src/server/reports/submit.njk
+++ b/src/server/reports/submit.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "overseas-sites-tables/macro.njk" import overseasSitesTables %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -79,16 +80,23 @@
         <p class="govuk-caption-l govuk-!-margin-bottom-1">{{ localise("reports:totalTonnageExported") }}</p>
         <p class="govuk-heading-l">{{ wasteExported.totalTonnage }}</p>
 
-        {% if wasteExported.overseasSiteRows | length > 0 %}
-          {{ govukTable({
-            head: [
-              { text: localise("reports:siteNameColumn") },
-              { text: localise("reports:osrIdColumn") },
-              { text: localise("reports:countryColumn") }
-            ],
-            rows: wasteExported.overseasSiteRows
-          }) }}
+        {% set overseasSiteHead = [
+            { text: localise("reports:siteNameColumn") },
+            { text: localise("reports:osrIdColumn") },
+            { text: localise("reports:countryColumn") }
+        ] %}
+        {% if showApprovalColumn %}
+          {% set overseasSiteHead = overseasSiteHead.concat([{ text: localise("reports:approvedColumn") }]) %}
         {% endif %}
+        {{ overseasSitesTables({
+          approvedRows: wasteExported.overseasSiteRows,
+          approvedHead: overseasSiteHead,
+          approvedHeading: localise("reports:overseasSitesHeading"),
+          unapprovedRows: wasteExported.unapprovedOverseasSiteRows,
+          unapprovedHead: [{ text: localise("reports:unapprovedOrsIdColumn") }],
+          unapprovedHeading: localise("reports:unapprovedOverseasSitesHeading"),
+          unapprovedIntro: localise("reports:unapprovedOverseasSitesIntro")
+        }) }}
 
         <h2 class="govuk-heading-l">{{ localise("reports:tonnageReceivedNotExportedHeading") }}</h2>
 


### PR DESCRIPTION
Ticket: [PAE-1323](https://eaflood.atlassian.net/browse/PAE-1323)

## Summary

- Replaces the plain overseas sites table on the submit page with the shared `overseasSitesTables` macro, matching the check-your-answers and view pages
- Adds Table 2 (unapproved/unresolved ORS IDs) with heading and explanatory intro text
- Adds the Approved column for accredited exporters, showing per-row approval status
- Renames the ORS ID column header from "Approved overseas reprocessor ID" to "Overseas reprocessor ID" across all report pages (column rename from previous commit, already merged as PR #754)

[PAE-1323]: https://eaflood.atlassian.net/browse/PAE-1323