### PR TITLE
PAE-1330: Remove FEATURE_FLAG_REGISTERED_ONLY from epr-frontend

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -323,12 +323,6 @@ export const config = convict({
       format: Boolean,
       default: false,
       env: 'FEATURE_FLAG_REPORTS'
-    },
-    registeredOnly: {
-      doc: 'Feature Flag: Enable registered only summary log uploads',
-      format: Boolean,
-      default: false,
-      env: 'FEATURE_FLAG_REGISTERED_ONLY'
     }
   }
 })
@@ -336,9 +330,6 @@ export const config = convict({
 config.validate({ allowed: 'strict' })
 
 export const isReportsEnabled = () => config.get('featureFlags.reports')
-
-export const isRegisteredOnlyEnabled = () =>
-  config.get('featureFlags.registeredOnly')
 
 /**
  * @import { Schema, SchemaObj } from 'convict'

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect } from 'vitest'
-import { config, isRegisteredOnlyEnabled, isReportsEnabled } from './config.js'
+import { config, isReportsEnabled } from './config.js'
 
 describe(isReportsEnabled, () => {
   afterEach(() => {
@@ -13,20 +13,5 @@ describe(isReportsEnabled, () => {
   it('should return true when flag is enabled', () => {
     config.set('featureFlags.reports', true)
     expect(isReportsEnabled()).toBe(true)
-  })
-})
-
-describe(isRegisteredOnlyEnabled, () => {
-  afterEach(() => {
-    config.reset('featureFlags.registeredOnly')
-  })
-
-  it('should return false by default', () => {
-    expect(isRegisteredOnlyEnabled()).toBe(false)
-  })
-
-  it('should return true when flag is enabled', () => {
-    config.set('featureFlags.registeredOnly', true)
-    expect(isRegisteredOnlyEnabled()).toBe(true)
   })
 })

--- a/src/server/organisations/controller.js
+++ b/src/server/organisations/controller.js
@@ -66,9 +66,9 @@ function createTag(status) {
  * @returns {string}
  */
 const formatWasteBalance = (accreditation, wasteBalance, localise) =>
-  !accreditation
-    ? localise('organisations:table:notApplicable')
-    : formatTonnage(wasteBalance?.availableAmount)
+  accreditation
+    ? formatTonnage(wasteBalance?.availableAmount)
+    : localise('organisations:table:notApplicable')
 
 /**
  * @param {Accreditation} [accreditation]

--- a/src/server/organisations/controller.js
+++ b/src/server/organisations/controller.js
@@ -1,6 +1,5 @@
 import { capitalize } from 'lodash-es'
 
-import { isRegisteredOnlyEnabled } from '#config/config.js'
 import { formatTonnage } from '#config/nunjucks/filters/format-tonnage.js'
 import { getDisplayMaterial } from '#server/common/helpers/materials/get-display-material.js'
 import { fetchOrganisationById } from '#server/common/helpers/organisations/fetch-organisation-by-id.js'
@@ -26,12 +25,8 @@ const isExcludedStatus = (status) => !status || EXCLUDED_STATUSES.has(status)
  * @param {Accreditation} [accreditation]
  * @returns {boolean}
  */
-const excludeAccreditation = (accreditation) => {
-  if (isRegisteredOnlyEnabled()) {
-    return accreditation && isExcludedStatus(accreditation.status)
-  }
-  return !accreditation || isExcludedStatus(accreditation.status)
-}
+const excludeAccreditation = (accreditation) =>
+  accreditation && isExcludedStatus(accreditation.status)
 
 /**
  * Determines whether a site should be rendered based on its registration
@@ -71,7 +66,7 @@ function createTag(status) {
  * @returns {string}
  */
 const formatWasteBalance = (accreditation, wasteBalance, localise) =>
-  isRegisteredOnlyEnabled() && !accreditation
+  !accreditation
     ? localise('organisations:table:notApplicable')
     : formatTonnage(wasteBalance?.availableAmount)
 
@@ -80,14 +75,10 @@ const formatWasteBalance = (accreditation, wasteBalance, localise) =>
  * @param {(key: string) => string} localise
  * @returns {string}
  */
-const createAccreditationTag = (accreditation, localise) => {
-  if (isRegisteredOnlyEnabled()) {
-    return createTag(
-      accreditation?.status ?? localise('organisations:table:notAccredited')
-    )
-  }
-  return createTag(accreditation.status)
-}
+const createAccreditationTag = (accreditation, localise) =>
+  createTag(
+    accreditation?.status ?? localise('organisations:table:notAccredited')
+  )
 
 /**
  * Creates a row for a given registration

--- a/src/server/organisations/controller.test.js
+++ b/src/server/organisations/controller.test.js
@@ -1,18 +1,12 @@
-import { config } from '#config/config.js'
 import { statusCodes } from '#server/common/constants/status-codes.js'
 import * as fetchOrganisationModule from '#server/common/helpers/organisations/fetch-organisation-by-id.js'
 import * as fetchWasteBalancesModule from '#server/common/helpers/waste-balance/fetch-waste-balances.js'
 import { it } from '#vite/fixtures/server.js'
 import Boom from '@hapi/boom'
-import {
-  getAllByRole,
-  getByRole,
-  getByText,
-  queryByText
-} from '@testing-library/dom'
+import { getAllByRole, getByRole, getByText } from '@testing-library/dom'
 import { load } from 'cheerio'
 import { JSDOM } from 'jsdom'
-import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest'
+import { beforeEach, describe, expect, vi } from 'vitest'
 
 /** @import {DOMWindow} from 'jsdom' */
 
@@ -365,101 +359,65 @@ describe('#organisationController', () => {
         ]
       }
 
-      afterAll(() => {
-        config.reset('featureFlags.registeredOnly')
+      it('should exclude registrations whose accreditation has an excluded status', async ({
+        server
+      }) => {
+        vi.mocked(
+          fetchOrganisationModule.fetchOrganisationById
+        ).mockResolvedValue({
+          ...fixtureData,
+          accreditations: [
+            {
+              id: 'acc-excluded-001',
+              status: 'created',
+              wasteProcessingType: 'reprocessor',
+              material: 'plastic'
+            }
+          ],
+          registrations: [
+            {
+              id: 'reg-with-excluded-acc',
+              accreditationId: 'acc-excluded-001',
+              status: 'approved',
+              wasteProcessingType: 'reprocessor',
+              material: 'plastic',
+              site: { address: { line1: 'Test Site' } }
+            }
+          ]
+        })
+
+        const { result, statusCode } = await server.inject({
+          method: 'GET',
+          url: '/organisations/6507f1f77bcf86cd79943901',
+          auth: mockAuth
+        })
+
+        const { body } = new JSDOM(result).window.document
+
+        expect(statusCode).toBe(statusCodes.ok)
+        expect(getByText(body, /No sites found/i)).toBeDefined()
       })
 
-      describe('feature flag off', () => {
-        beforeAll(() => {
-          config.set('featureFlags.registeredOnly', false)
+      it('should show registered-only', async ({ server }) => {
+        vi.mocked(
+          fetchOrganisationModule.fetchOrganisationById
+        ).mockResolvedValue(registeredOnlyOrganisation)
+
+        const { result, statusCode } = await server.inject({
+          method: 'GET',
+          url: '/organisations/6507f1f77bcf86cd79943901',
+          auth: mockAuth
         })
 
-        it('should hide registered-only when flag is off', async ({
-          server
-        }) => {
-          vi.mocked(
-            fetchOrganisationModule.fetchOrganisationById
-          ).mockResolvedValue(registeredOnlyOrganisation)
+        const { body } = new JSDOM(result).window.document
+        const cell = cellInColumn(getByRole(body, 'table'))
 
-          const { result, statusCode } = await server.inject({
-            method: 'GET',
-            url: '/organisations/6507f1f77bcf86cd79943901',
-            auth: mockAuth
-          })
-
-          const { body } = new JSDOM(result).window.document
-
-          expect(statusCode).toBe(statusCodes.ok)
-          expect(getByText(body, /No sites found/i)).toBeDefined()
-          expect(queryByText(body, /Not accredited/i)).toBeNull()
-        })
-      })
-
-      describe('feature flag on', () => {
-        beforeAll(() => {
-          config.set('featureFlags.registeredOnly', true)
-        })
-
-        it('should exclude registrations whose accreditation has an excluded status', async ({
-          server
-        }) => {
-          vi.mocked(
-            fetchOrganisationModule.fetchOrganisationById
-          ).mockResolvedValue({
-            ...fixtureData,
-            accreditations: [
-              {
-                id: 'acc-excluded-001',
-                status: 'created',
-                wasteProcessingType: 'reprocessor',
-                material: 'plastic'
-              }
-            ],
-            registrations: [
-              {
-                id: 'reg-with-excluded-acc',
-                accreditationId: 'acc-excluded-001',
-                status: 'approved',
-                wasteProcessingType: 'reprocessor',
-                material: 'plastic',
-                site: { address: { line1: 'Test Site' } }
-              }
-            ]
-          })
-
-          const { result, statusCode } = await server.inject({
-            method: 'GET',
-            url: '/organisations/6507f1f77bcf86cd79943901',
-            auth: mockAuth
-          })
-
-          const { body } = new JSDOM(result).window.document
-
-          expect(statusCode).toBe(statusCodes.ok)
-          expect(getByText(body, /No sites found/i)).toBeDefined()
-        })
-
-        it('should show registered-only', async ({ server }) => {
-          vi.mocked(
-            fetchOrganisationModule.fetchOrganisationById
-          ).mockResolvedValue(registeredOnlyOrganisation)
-
-          const { result, statusCode } = await server.inject({
-            method: 'GET',
-            url: '/organisations/6507f1f77bcf86cd79943901',
-            auth: mockAuth
-          })
-
-          const { body } = new JSDOM(result).window.document
-          const cell = cellInColumn(getByRole(body, 'table'))
-
-          expect(statusCode).toBe(statusCodes.ok)
-          expect(cell('Material')).toHaveTextContent(/Plastic/i)
-          expect(cell('Accreditation')).toHaveTextContent(/Not accredited/i)
-          expect(cell(/Available waste balance/)).toHaveTextContent(
-            'Not applicable'
-          )
-        })
+        expect(statusCode).toBe(statusCodes.ok)
+        expect(cell('Material')).toHaveTextContent(/Plastic/i)
+        expect(cell('Accreditation')).toHaveTextContent(/Not accredited/i)
+        expect(cell(/Available waste balance/)).toHaveTextContent(
+          'Not applicable'
+        )
       })
     })
 

--- a/src/server/registrations/controller.js
+++ b/src/server/registrations/controller.js
@@ -1,10 +1,9 @@
-import { config, isRegisteredOnlyEnabled } from '#config/config.js'
+import { config } from '#config/config.js'
 import { getDisplayMaterial } from '#server/common/helpers/materials/get-display-material.js'
 import { fetchRegistrationAndAccreditation } from '#server/common/helpers/organisations/fetch-registration-and-accreditation.js'
 import { getNoteTypeDisplayNames } from '#server/common/helpers/prns/registration-helpers.js'
 import { getWasteBalance } from '#server/common/helpers/waste-balance/get-waste-balance.js'
 import { getStatusClass } from '#server/organisations/helpers/status-helpers.js'
-import Boom from '@hapi/boom'
 import { capitalize } from 'lodash-es'
 
 /**
@@ -22,10 +21,6 @@ export const controller = {
         registrationId,
         session.idToken
       )
-
-    if (!isRegisteredOnlyEnabled() && !accreditation) {
-      throw Boom.notFound('Registered-only not enabled')
-    }
 
     const wasteBalance = registration.accreditationId
       ? await getWasteBalance(

--- a/src/server/registrations/controller.test.js
+++ b/src/server/registrations/controller.test.js
@@ -12,15 +12,7 @@ import {
 } from '@testing-library/dom'
 import { load } from 'cheerio'
 import { JSDOM } from 'jsdom'
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  vi
-} from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest'
 
 import fixtureExportingOnly from '../../../fixtures/organisation/fixture-exporting-only.json' with { type: 'json' }
 import fixtureData from '../../../fixtures/organisation/organisationData.json' with { type: 'json' }
@@ -73,11 +65,6 @@ describe('#accreditationDashboardController', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(fetchWasteBalancesModule.fetchWasteBalances).mockResolvedValue({})
-    config.set('featureFlags.registeredOnly', true)
-  })
-
-  afterEach(() => {
-    config.reset('featureFlags.registeredOnly')
   })
 
   describe('happy path - reprocessor', () => {
@@ -770,7 +757,7 @@ describe('#accreditationDashboardController', () => {
     })
   })
 
-  describe('registered-only flag', () => {
+  describe('registered-only', () => {
     const registeredOnlyRegistration = {
       registration: glassApproved.registration,
       accreditation: undefined
@@ -782,129 +769,46 @@ describe('#accreditationDashboardController', () => {
       )
     })
 
-    describe('when flag is enabled', () => {
-      it('should return 200 for registered-only operator', async ({
-        server
-      }) => {
-        const { statusCode } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        expect(statusCode).toBe(statusCodes.ok)
+    it('should return 200 for registered-only operator', async ({ server }) => {
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
+        auth: mockAuth
       })
 
-      it('should not show waste balance banner for registered-only operator', async ({
-        server
-      }) => {
-        const { result } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        const dom = new JSDOM(result)
-        const { body } = dom.window.document
-
-        expect(queryByText(body, /Available waste balance/)).toBeNull()
-      })
-
-      it('should not show PRNs card for registered-only operator', async ({
-        server
-      }) => {
-        const { result } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        const dom = new JSDOM(result)
-        const { body } = dom.window.document
-
-        expect(
-          queryByRole(body, 'heading', { name: /PRN|PERN/i, level: 3 })
-        ).toBeNull()
-      })
+      expect(statusCode).toBe(statusCodes.ok)
     })
 
-    describe('when flag is disabled', () => {
-      beforeEach(() => {
-        config.set('featureFlags.registeredOnly', false)
+    it('should not show waste balance banner for registered-only operator', async ({
+      server
+    }) => {
+      const { result } = await server.inject({
+        method: 'GET',
+        url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
+        auth: mockAuth
       })
 
-      it('should show PRNs card for accredited operator', async ({
-        server
-      }) => {
-        vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
-          glassApproved
-        )
+      const dom = new JSDOM(result)
+      const { body } = dom.window.document
 
-        const { result } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
+      expect(queryByText(body, /Available waste balance/)).toBeNull()
+    })
 
-        const dom = new JSDOM(result)
-        const { body } = dom.window.document
-
-        expect(
-          queryByRole(body, 'heading', { name: /PRN|PERN/i, level: 3 })
-        ).not.toBeNull()
+    it('should not show PRNs card for registered-only operator', async ({
+      server
+    }) => {
+      const { result } = await server.inject({
+        method: 'GET',
+        url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
+        auth: mockAuth
       })
 
-      it('should show waste balance banner for accredited operator', async ({
-        server
-      }) => {
-        vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
-          glassApproved
-        )
-        vi.mocked(
-          fetchWasteBalancesModule.fetchWasteBalances
-        ).mockResolvedValue({
-          'acc-001-glass-approved': { amount: 1000, availableAmount: 500 }
-        })
+      const dom = new JSDOM(result)
+      const { body } = dom.window.document
 
-        const { result } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        const dom = new JSDOM(result)
-        const { body } = dom.window.document
-
-        expect(queryByText(body, /Available waste balance/)).not.toBeNull()
-      })
-
-      it('should return 404 for registered-only operator', async ({
-        server
-      }) => {
-        const { statusCode } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        expect(statusCode).toBe(statusCodes.notFound)
-      })
-
-      it('should still return 200 for accredited operator', async ({
-        server
-      }) => {
-        vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
-          glassApproved
-        )
-
-        const { statusCode } = await server.inject({
-          method: 'GET',
-          url: '/organisations/6507f1f77bcf86cd79943901/registrations/reg-001-glass-approved',
-          auth: mockAuth
-        })
-
-        expect(statusCode).toBe(statusCodes.ok)
-      })
+      expect(
+        queryByRole(body, 'heading', { name: /PRN|PERN/i, level: 3 })
+      ).toBeNull()
     })
   })
 


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

- Remove the `FEATURE_FLAG_REGISTERED_ONLY` convict config entry and `isRegisteredOnlyEnabled()` helper from epr-frontend
- Make all gated code paths unconditional, preserving the flag-on behaviour (registered-only operators are always supported)
- Remove flag-toggling test scaffolding and flag-off test branches

Part of PAE-1330 (remove obsolete feature flags).

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ