### PR TITLE
PAE-0000: harden report redirect path construction

### DIFF
--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -1,6 +1,6 @@
 import { fetchReportDetail } from './fetch-report-detail.js'
 import { periodParamsSchema } from './period-params-schema.js'
-import { getRedirectUrl } from './redirect.js'
+import { getContinueRedirectUrl, getSaveRedirectUrl } from './redirect.js'
 import { updateReport } from './update-report.js'
 import { buildValidationErrors } from './validation.js'
 
@@ -142,7 +142,9 @@ function createSimplePostHandler(fieldName, nextPage) {
     )
 
     return h.redirect(
-      getRedirectUrl(request, request.params, request.payload.action, nextPage)
+      request.payload.action === 'continue'
+        ? getContinueRedirectUrl(request, request.params, nextPage)
+        : getSaveRedirectUrl(request, request.params)
     )
   }
 }
@@ -208,7 +210,9 @@ function createTonnagePostHandler(
     )
 
     return h.redirect(
-      getRedirectUrl(request, request.params, request.payload.action, nextPage)
+      request.payload.action === 'continue'
+        ? getContinueRedirectUrl(request, request.params, nextPage)
+        : getSaveRedirectUrl(request, request.params)
     )
   }
 }

--- a/src/server/reports/helpers/redirect.js
+++ b/src/server/reports/helpers/redirect.js
@@ -1,22 +1,30 @@
+function buildBasePath({ organisationId, registrationId }) {
+  return `/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports`
+}
+
 /**
- * Returns the redirect URL for save (reports list) or continue (next page).
+ * Returns the redirect URL for the save action (reports list page).
+ * @param {Request} request
+ * @param {{ organisationId: string, registrationId: string }} params
+ * @returns {string}
+ */
+export function getSaveRedirectUrl(request, params) {
+  return request.localiseUrl(buildBasePath(params))
+}
+
+/**
+ * Returns the redirect URL for the continue action (next data-entry page).
  * @param {Request} request
  * @param {{ organisationId: string, registrationId: string, year: number, cadence: string, period: number }} params
- * @param {string} action - 'continue' or 'save'
  * @param {string} nextPage - path segment for the continue destination (e.g. 'free-perns')
  * @returns {string}
  */
-export function getRedirectUrl(request, params, action, nextPage) {
-  const { organisationId, registrationId, year, cadence, period } = params
-  const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports`
-
-  if (action === 'continue') {
-    return request.localiseUrl(
-      `${basePath}/${year}/${cadence}/${period}/${nextPage}`
-    )
-  }
-
-  return request.localiseUrl(basePath)
+export function getContinueRedirectUrl(request, params, nextPage) {
+  const { year, cadence, period } = params
+  const basePath = buildBasePath(params)
+  return request.localiseUrl(
+    `${basePath}/${encodeURIComponent(year)}/${encodeURIComponent(cadence)}/${encodeURIComponent(period)}/${encodeURIComponent(nextPage)}`
+  )
 }
 
 /**

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.js
@@ -1,7 +1,10 @@
 import { CADENCE } from '../constants.js'
 import { createDataPageControllers } from '../helpers/create-data-page-controllers.js'
 import { tonnageNotRecycledPayloadSchema } from '../helpers/validation.js'
-import { getRedirectUrl } from '../helpers/redirect.js'
+import {
+  getContinueRedirectUrl,
+  getSaveRedirectUrl
+} from '../helpers/redirect.js'
 import { updateReport } from '../helpers/update-report.js'
 import { buildReprocessorViewData } from './reprocessor-page-guards.js'
 
@@ -50,7 +53,9 @@ const { getController, postController } = createDataPageControllers({
         cadence === CADENCE.MONTHLY ? 'prn-summary' : 'supporting-information'
 
       return h.redirect(
-        getRedirectUrl(request, request.params, action, nextPage)
+        action === 'continue'
+          ? getContinueRedirectUrl(request, request.params, nextPage)
+          : getSaveRedirectUrl(request, request.params)
       )
     }
   }


### PR DESCRIPTION
Ticket: [PAE-0000](https://eaflood.atlassian.net/browse/PAE-0000)
## Summary

- Snyk Code flagged three Medium "Open Redirect" findings in the reports redirect helper (`create-data-page-controllers.js:144/210`, `tonnes-not-recycled-controller.js:52`). The user-controlled `action` payload only ever picks between two fully server-controlled URLs, so the sinks are structurally safe — but two defensive improvements are worth keeping.
- Split `getRedirectUrl(action, ...)` into `getContinueRedirectUrl` and `getSaveRedirectUrl`, so `action` is now a branch selector at the call site rather than a parameter to the URL-building function.
- Apply `encodeURIComponent` to every path segment (`organisationId`, `registrationId`, `year`, `cadence`, `period`, `nextPage`) so unexpected characters can't escape a segment.

## Snyk follow-up

Snyk's taint analyzer still flags the three sinks after these changes — the engine doesn't recognise the ternary-over-hardcoded-alternatives pattern as a sanitizer. The findings should be marked **Accept Risk / False Positive** in the Snyk UI (finding IDs: `38516a80-a0fd-422e-ae8e-832fad22108d`, `cbaa4057-90c3-400b-88a6-f02c245faa97`, `28a1e0ce-f613-4a3d-95e4-d15f4d118c36`).

## Changes

- `src/server/reports/helpers/redirect.js` — replace single `getRedirectUrl` with `getContinueRedirectUrl` + `getSaveRedirectUrl`; encode every path segment via `encodeURIComponent`; share a `buildBasePath` internal helper.
- `src/server/reports/helpers/create-data-page-controllers.js` — update both POST handlers to call the appropriate helper based on `request.payload.action`.
- `src/server/reports/reprocessor/tonnes-not-recycled-controller.js` — same update for the custom POST handler.

Test fixtures in the reports package all use URL-safe IDs (`org-123`, `reg-001`, etc.) so the encoding is idempotent — existing assertions against `headers.location` still hold.
