### PR TITLE
PAE-1342: guard check-answers page against non-in_progress reports

### DIFF
--- a/src/server/reports/check-controller.js
+++ b/src/server/reports/check-controller.js
@@ -196,6 +196,14 @@ export const checkGetController = {
       session.idToken
     )
 
+    if (reportDetail.status.currentStatus !== SUBMISSION_STATUS.IN_PROGRESS) {
+      return h.redirect(
+        request.localiseUrl(
+          `/organisations/${organisationId}/registrations/${registrationId}/reports`
+        )
+      )
+    }
+
     const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
     const material = getDisplayMaterial(registration)
     const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -70,7 +70,7 @@ const exporterReportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: 'Supply chain disruption in February',
   recyclingActivity: {
     totalTonnageReceived: 80.25,
@@ -148,7 +148,7 @@ const reprocessorReportDetail = {
   },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 80.25,
@@ -1671,6 +1671,31 @@ describe('#checkController', () => {
 
           expect(body.textContent).toContain('Average price per tonne')
           expect(body.textContent).toContain('£0.00')
+        })
+      })
+
+      describe('when report status is not in_progress', () => {
+        beforeEach(() => {
+          vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
+            exporterRegistration
+          )
+          vi.mocked(fetchReportDetail).mockResolvedValue({
+            ...exporterReportDetail,
+            status: { currentStatus: 'ready_to_submit' }
+          })
+        })
+
+        it('should redirect to reports list', async ({ server }) => {
+          const { statusCode, headers } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toContain(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
         })
       })
     })


### PR DESCRIPTION
Ticket: [PAE-1342](https://eaflood.atlassian.net/browse/PAE-1342)
## Changes

- Add status guard to `checkGetController.handler` that redirects to the reports list when the report is not `in_progress`
- Update fixtures in `check-controller.test.js` to use the correct `{ currentStatus }` object shape
- Add unit test asserting a 302 redirect to the reports list when status is `ready_to_submit`

## Context

Fixes a bug where navigating back from the creation-confirmation page lands on check-answers with a `ready_to_submit` report, and clicking "Create Report" returns a 400 error.

[PAE-1342]: https://eaflood.atlassian.net/browse/PAE-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ