### PR TITLE
PAE-1339: Introduce HapiRequest JSDoc typedef and apply to auth entry points

### DIFF
--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -16,7 +16,7 @@
 
 /**
  * Authenticated request auth data. `credentials` holds the UserSession
- * populated by @hapi/cookie on behalf of our Defra ID bell strategy.
+ * populated by `@hapi/cookie` on behalf of our Defra ID bell strategy.
  *
  * Note: Hapi's own `RequestAuth.credentials` is non-nullable regardless of
  * route auth mode. Routes that register with `auth: { mode: 'try' }` or
@@ -34,8 +34,8 @@
  *   - `t`, `i18n` from i18next-http-middleware
  *   - `localiseUrl` from src/server/common/helpers/i18next.js
  *   - `wasteOrganisationsService` from the waste organisations plugin
- *   - `metrics` from @defra/cdp-metrics
- *   - `cookieAuth` from @hapi/cookie
+ *   - `metrics` from `@defra/cdp-metrics`
+ *   - `cookieAuth` from `@hapi/cookie`
  *   - `auth.credentials` narrowed to `UserSession`
  * @typedef {Omit<Request, 'auth'> & {
  *   auth: RequestAuth,

--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -9,7 +9,7 @@
 /**
  * @typedef {{
  *   set: (session: object) => void,
- *   clear: (key?: string) => void,
+ *   clear: () => void,
  *   ttl: (msecs: number) => void
  * }} CookieAuth
  */
@@ -17,6 +17,12 @@
 /**
  * Authenticated request auth data. `credentials` holds the UserSession
  * populated by @hapi/cookie on behalf of our Defra ID bell strategy.
+ *
+ * Note: Hapi's own `RequestAuth.credentials` is non-nullable regardless of
+ * route auth mode. Routes that register with `auth: { mode: 'try' }` or
+ * `auth: false` should still keep their runtime `if (!credentials)` guards;
+ * this type follows Hapi's convention rather than modelling the 'try'-mode
+ * nuance in the type system.
  * @typedef {Omit<Request['auth'], 'credentials'> & {
  *   credentials: UserSession
  * }} RequestAuth
@@ -30,10 +36,7 @@
  *   - `wasteOrganisationsService` from the waste organisations plugin
  *   - `metrics` from @defra/cdp-metrics
  *   - `cookieAuth` from @hapi/cookie
- *   - `auth.credentials` narrowed to UserSession (populated by the Defra ID
- *     bell strategy)
- *
- * Mirrors the pattern used in epr-backend/src/common/hapi-types.js.
+ *   - `auth.credentials` narrowed to `UserSession`
  * @typedef {Omit<Request, 'auth'> & {
  *   auth: RequestAuth,
  *   t: TFunction,

--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -1,0 +1,48 @@
+/**
+ * @import {Request} from '@hapi/hapi'
+ * @import {TFunction, i18n} from 'i18next'
+ * @import {Metrics} from '@defra/cdp-metrics'
+ * @import {WasteOrganisationsService} from './helpers/waste-organisations/port.js'
+ * @import {UserSession} from '../auth/types/session.js'
+ */
+
+/**
+ * @typedef {{
+ *   set: (session: object) => void,
+ *   clear: (key?: string) => void,
+ *   ttl: (msecs: number) => void
+ * }} CookieAuth
+ */
+
+/**
+ * Authenticated request auth data. `credentials` holds the UserSession
+ * populated by @hapi/cookie on behalf of our Defra ID bell strategy.
+ * @typedef {Omit<Request['auth'], 'credentials'> & {
+ *   credentials: UserSession
+ * }} RequestAuth
+ */
+
+/**
+ * Hapi request extended with the decorations contributed by the app's
+ * registered plugins:
+ *   - `t`, `i18n` from i18next-http-middleware
+ *   - `localiseUrl` from src/server/common/helpers/i18next.js
+ *   - `wasteOrganisationsService` from the waste organisations plugin
+ *   - `metrics` from @defra/cdp-metrics
+ *   - `cookieAuth` from @hapi/cookie
+ *   - `auth.credentials` narrowed to UserSession (populated by the Defra ID
+ *     bell strategy)
+ *
+ * Mirrors the pattern used in epr-backend/src/common/hapi-types.js.
+ * @typedef {Omit<Request, 'auth'> & {
+ *   auth: RequestAuth,
+ *   t: TFunction,
+ *   i18n: i18n,
+ *   localiseUrl: (url: string) => string,
+ *   wasteOrganisationsService: WasteOrganisationsService,
+ *   metrics: () => Metrics,
+ *   cookieAuth: CookieAuth
+ * }} HapiRequest
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/home/controller.js
+++ b/src/server/home/controller.js
@@ -10,7 +10,7 @@ const SUMMARY_LOGS_OVERVIEW_URL =
 
 /**
  * Determines the appropriate href for the "Start now" button based on auth state
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @returns {Promise<string>} The href for the start button
  */
 async function getStartNowHref(request) {
@@ -32,6 +32,10 @@ async function getStartNowHref(request) {
  * @satisfies {Partial<ServerRoute>}
  */
 export const controller = {
+  /**
+   * @param {HapiRequest} request
+   * @param {import('@hapi/hapi').ResponseToolkit} h
+   */
   handler: async (request, h) => {
     const { t: localise } = request
     const startNowHref = await getStartNowHref(request)
@@ -51,11 +55,16 @@ export const controller = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const redirectToStart = {
+  /**
+   * @param {HapiRequest} request
+   * @param {import('@hapi/hapi').ResponseToolkit} h
+   */
   handler(request, h) {
     return h.redirect(request.localiseUrl('/start'))
   }
 }
 
 /**
- * @import { ServerRoute, Request } from '@hapi/hapi'
+ * @import { ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/home/controller.js
+++ b/src/server/home/controller.js
@@ -34,7 +34,7 @@ async function getStartNowHref(request) {
 export const controller = {
   /**
    * @param {HapiRequest} request
-   * @param {import('@hapi/hapi').ResponseToolkit} h
+   * @param {ResponseToolkit} h
    */
   handler: async (request, h) => {
     const { t: localise } = request
@@ -57,7 +57,7 @@ export const controller = {
 export const redirectToStart = {
   /**
    * @param {HapiRequest} request
-   * @param {import('@hapi/hapi').ResponseToolkit} h
+   * @param {ResponseToolkit} h
    */
   handler(request, h) {
     return h.redirect(request.localiseUrl('/start'))
@@ -65,6 +65,6 @@ export const redirectToStart = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
  * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/logged-out/controller.js
+++ b/src/server/logged-out/controller.js
@@ -5,6 +5,10 @@
  */
 
 const controller = {
+  /**
+   * @param {HapiRequest} request
+   * @param {ResponseToolkit} h
+   */
   handler(request, h) {
     if (request.auth.credentials) {
       // If user is not logged out, redirect to home page
@@ -22,5 +26,6 @@ const controller = {
 export { controller }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/logout/controller.js
+++ b/src/server/logout/controller.js
@@ -4,7 +4,10 @@ import { removeUserSession } from '#server/auth/helpers/user-session.js'
 import { auditSignOut } from '#server/common/helpers/auditing/index.js'
 import { metrics } from '#server/common/helpers/metrics/index.js'
 
-/** @import { ServerRoute } from '@hapi/hapi' */
+/**
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ */
 
 /**
  * Logout controller
@@ -12,6 +15,10 @@ import { metrics } from '#server/common/helpers/metrics/index.js'
  * @satisfies {Partial<ServerRoute>}
  */
 const logoutController = {
+  /**
+   * @param {HapiRequest} request
+   * @param {ResponseToolkit} h
+   */
   handler: async (request, h) => {
     const session = request.auth.credentials
 


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

First incremental slice of PAE-1339, which eliminates the 388 pre-existing
errors reported by `npm run lint:types` across epr-frontend. This PR lays the
foundation: a shared `HapiRequest` JSDoc typedef that the rest of the
handlers will adopt over subsequent PRs.

The typedef mirrors the approach in `epr-backend/src/common/hapi-types.js` —
a JSDoc intersection of `@hapi/hapi`'s `Request` with the decorations
contributed by the app's plugins:

- `t`, `i18n` from i18next-http-middleware
- `localiseUrl` from `src/server/common/helpers/i18next.js`
- `wasteOrganisationsService` from the waste organisations plugin
- `metrics` from `@defra/cdp-metrics`
- `cookieAuth` from `@hapi/cookie`
- `auth.credentials` narrowed to `UserSession`

The typedef is applied to the three auth entry-point handlers — `/`,
`/start`, `/logout`, `/logged-out` — as the first slice. `npm run lint:types`
errors drop from 388 to 376. Subsequent PRs will expand application across
the remaining ~80 handlers.

Intentionally uses JSDoc only (no `.d.ts`, no `declare module`) to stay
consistent with the direction the rest of the Defra services have chosen.

## Notes

- Hapi's own `RequestAuth.credentials` is non-nullable regardless of route
  auth mode. Routes registered with `auth: { mode: 'try' }` or `auth: false`
  (including all three handlers touched here) still keep their runtime
  `if (!credentials)` guards as defensive programming. The typedef follows
  Hapi's own convention rather than modelling the 'try'-mode nuance in the
  type system.
- `CookieAuth.clear()` is typed without the optional `key` argument because
  no caller uses the keyed form.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ