### PR TITLE
PAE-1343: Fix delete confirmation back link to honour the actual referring page

### DIFF
--- a/src/server/reports/delete-controller.js
+++ b/src/server/reports/delete-controller.js
@@ -10,6 +10,35 @@ const payloadSchema = Joi.object({
   crumb: Joi.string()
 })
 
+function resolveBackUrl(request) {
+  const { organisationId, registrationId } = request.params
+  const fallback = request.localiseUrl(
+    `/organisations/${organisationId}/registrations/${registrationId}/reports`
+  )
+
+  const { referrer } = request.info
+  if (!referrer) {
+    return fallback
+  }
+
+  let refererUrl
+  try {
+    refererUrl = new URL(referrer)
+  } catch {
+    return fallback
+  }
+
+  if (refererUrl.host !== request.info.host) {
+    return fallback
+  }
+
+  if (refererUrl.pathname === request.path) {
+    return fallback
+  }
+
+  return refererUrl.pathname + refererUrl.search
+}
+
 /**
  * @satisfies {Partial<ServerRoute>}
  */
@@ -40,9 +69,7 @@ export const deleteGetController = {
       bodyWarning: localise('reports:deleteBodyWarning'),
       bodyGuidance: localise('reports:deleteBodyGuidance'),
       confirmButtonText: localise('reports:deleteConfirmButton'),
-      backUrl: request.localiseUrl(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/supporting-information`
-      )
+      backUrl: resolveBackUrl(request)
     }
 
     return h.view('reports/confirm-delete', viewData)

--- a/src/server/reports/delete-controller.test.js
+++ b/src/server/reports/delete-controller.test.js
@@ -107,24 +107,114 @@ describe('#deleteController', () => {
         expect(button?.textContent?.trim()).toContain('Confirm deletion')
       })
 
-      it('should display back link to supporting information page', async ({
-        server
-      }) => {
-        const { result } = await server.inject({
-          method: 'GET',
-          url: baseUrl,
-          auth: mockAuth
+      describe('back link', () => {
+        const host = 'localhost'
+        const refererFor = (path) => `http://${host}${path}`
+        const reportsListPath = `/organisations/${organisationId}/registrations/${registrationId}/reports`
+        const periodPrefix = `${reportsListPath}/2026/quarterly/1`
+
+        it('should fall back to the reports list when no referer header is present', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { host }
+          })
+
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(reportsListPath)
         })
 
-        const dom = new JSDOM(result)
-        const { body } = dom.window.document
+        it('should use the referer pathname as the back link when the referer is same-origin', async ({
+          server
+        }) => {
+          const checkYourAnswersPath = `${periodPrefix}/check-your-answers`
 
-        const backLink = body.querySelector('.govuk-back-link')
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { host, referer: refererFor(checkYourAnswersPath) }
+          })
 
-        expect(backLink).not.toBeNull()
-        expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
-        )
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(checkYourAnswersPath)
+        })
+
+        it('should preserve the query string from the referer', async ({
+          server
+        }) => {
+          const refererPath = `${periodPrefix}/tonnage-input?step=2`
+
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { host, referer: refererFor(refererPath) }
+          })
+
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(refererPath)
+        })
+
+        it('should fall back to the reports list when the referer is cross-origin', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: {
+              host,
+              referer: 'https://evil.example.com/stolen'
+            }
+          })
+
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(reportsListPath)
+        })
+
+        it('should fall back to the reports list when the referer is malformed', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { host, referer: 'not-a-valid-url' }
+          })
+
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(reportsListPath)
+        })
+
+        it('should fall back to the reports list when the referer points to the delete page itself', async ({
+          server
+        }) => {
+          const { result } = await server.inject({
+            method: 'GET',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { host, referer: refererFor(baseUrl) }
+          })
+
+          const dom = new JSDOM(result)
+          const backLink = dom.window.document.querySelector('.govuk-back-link')
+
+          expect(backLink?.getAttribute('href')).toBe(reportsListPath)
+        })
       })
 
       it('should display the warning and guidance text', async ({ server }) => {


### PR DESCRIPTION
Ticket: [PAE-1343](https://eaflood.atlassian.net/browse/PAE-1343)
## Summary
Fixes the back link on the report deletion confirmation page so it returns the user to the page they were actually on before clicking "Delete report", rather than always sending them to the Supporting Information page.

## What Changed
- Back link on the delete confirmation page is now resolved from the HTTP Referer header (same-origin only) instead of a hardcoded path
- Falls back to the reports list when the referer is missing, cross-origin, malformed, or self-referential (e.g. page refresh)
- Replaced the single supporting-information assertion with six integration tests covering each resolution path

## Why
The back link was hardcoded to Supporting Information, which was only correct for one of the five pages that can navigate to the delete confirmation. Users deleting a report from Check Your Answers, Tonnage Input, PRN Summary, or Submit were silently redirected to a page they had not come from. Reading the referer keeps the fix contained to a single controller with no changes to any of the calling pages, and the reports list is a safe neutral landing when the referer cannot be trusted.

[PAE-1343]: https://eaflood.atlassian.net/browse/PAE-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ