### PR TITLE
PAE-1349: display registration number on detail page and site on submit page

### DIFF
--- a/src/server/reports/detail-controller.js
+++ b/src/server/reports/detail-controller.js
@@ -143,6 +143,7 @@ function buildViewData(
         }
       : null,
     accreditation: accreditation?.accreditationNumber,
+    registrationNumber: registration.registrationNumber,
     site: reportDetail.details.site,
     wasteReceived: {
       totalTonnage: recyclingActivity.totalTonnageReceived,

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -601,6 +601,37 @@ describe('#detailReportsController', () => {
         expect(body.textContent).toContain('North Road')
       })
 
+      it('should display registration number in details section', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: detailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(body.textContent).toContain('Registration:')
+        expect(body.textContent).toContain('REG001234')
+      })
+
+      it('should display details heading', async ({ server }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: detailUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+
+        expect(
+          getByRole(body, 'heading', { name: /Details/, level: 2 })
+        ).toBeDefined()
+      })
+
       it('should display waste received heading', async ({ server }) => {
         const { result } = await server.inject({
           method: 'GET',
@@ -946,6 +977,7 @@ describe('#detailReportsController', () => {
 
         expect(body.textContent).toContain('Accreditation:')
         expect(body.textContent).toContain('ER992415095748M')
+        expect(body.textContent).not.toContain('Registration:')
       })
 
       it('should display site details', async ({ server }) => {
@@ -1055,7 +1087,9 @@ describe('#detailReportsController', () => {
         expect(heading).toBeDefined()
       })
 
-      it('should not display details section', async ({ server }) => {
+      it('should display registration number in details section', async ({
+        server
+      }) => {
         const { result } = await server.inject({
           method: 'GET',
           url: exporterDetailUrl,
@@ -1066,11 +1100,10 @@ describe('#detailReportsController', () => {
         const { body } = dom.window.document
 
         expect(
-          queryByRole(body, 'heading', {
-            name: /Details/,
-            level: 2
-          })
-        ).toBeNull()
+          getByRole(body, 'heading', { name: /Details/, level: 2 })
+        ).toBeDefined()
+        expect(body.textContent).toContain('Registration:')
+        expect(body.textContent).toContain('REG002345')
       })
 
       it('should display waste received for export heading', async ({

--- a/src/server/reports/detail.njk
+++ b/src/server/reports/detail.njk
@@ -35,17 +35,16 @@
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      {% if accreditation or site %}
-        <h2 class="govuk-heading-l">{{ localise("reports:detailsHeading") }}</h2>
-        {% if accreditation %}
-          <p class="govuk-body"><strong>{{ localise("reports:accreditationLabel") }}:</strong> {{ accreditation }}</p>
-        {% endif %}
-        <p class="govuk-body"><strong>{{ localise("reports:materialLabel") }}:</strong> {{ material }}</p>
-        {% if site %}
-          <p class="govuk-body"><strong>{{ localise("reports:siteLabel") }}:</strong> {{ site.address.line1 }}</p>
-        {% endif %}
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <h2 class="govuk-heading-l">{{ localise("reports:detailsHeading") }}</h2>
+      <p class="govuk-body">
+        <strong>{{ localise("reports:accreditationLabel") if accreditation else localise("reports:registrationLabel") }}:</strong>
+        {{ accreditation if accreditation else registrationNumber }}
+      </p>
+      <p class="govuk-body"><strong>{{ localise("reports:materialLabel") }}:</strong> {{ material }}</p>
+      {% if site %}
+        <p class="govuk-body"><strong>{{ localise("reports:siteLabel") }}:</strong> {{ site.address.line1 }}</p>
       {% endif %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l">{{ wasteReceivedHeading }}</h2>
       {% if isExporter %}

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -253,6 +253,7 @@ function buildViewData({
     // Your report summary list
     periodLabel,
     material,
+    site: reportDetail.details.site,
 
     // Waste received
     wasteReceived: buildWasteReceivedViewData(recyclingActivity),

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -380,6 +380,19 @@ describe('#submitController', () => {
           expect(body.textContent).toContain('Plastic')
         })
 
+        it('should not display site row when no site present', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          const summaryKeys = [
+            ...body.querySelectorAll('.govuk-summary-list__key')
+          ]
+          expect(summaryKeys.some((k) => k.textContent.includes('Site'))).toBe(
+            false
+          )
+        })
+
         // Waste received section
 
         it('should display Packaging waste received for exporting heading', async ({
@@ -1080,6 +1093,15 @@ describe('#submitController', () => {
           expect(
             queryByRole(body, 'heading', { name: /^PRNs$/i, level: 2 })
           ).toBeNull()
+        })
+
+        it('should display site address in Your report summary list', async ({
+          server
+        }) => {
+          const body = await getBody(server)
+
+          expect(body.textContent).toContain('Site')
+          expect(body.textContent).toContain('North Road')
         })
       })
 

--- a/src/server/reports/submit.njk
+++ b/src/server/reports/submit.njk
@@ -41,18 +41,17 @@
 
       <h2 class="govuk-heading-l">{{ localise("reports:submitYourReportHeading") }}</h2>
 
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: { text: localise("reports:periodColumn") },
-            value: { text: periodLabel }
-          },
-          {
-            key: { text: localise("reports:materialLabel") },
-            value: { text: material }
-          }
-        ]
-      }) }}
+      {% set yourReportRows = [
+        { key: { text: localise("reports:periodColumn") }, value: { text: periodLabel } },
+        { key: { text: localise("reports:materialLabel") }, value: { text: material } }
+      ] %}
+      {% if site %}
+        {% set yourReportRows = yourReportRows.concat([{
+          key: { text: localise("reports:siteLabel") },
+          value: { text: site.address.line1 }
+        }]) %}
+      {% endif %}
+      {{ govukSummaryList({ rows: yourReportRows }) }}
 
       <h2 class="govuk-heading-l">{{ wasteReceivedHeading }}</h2>
 


### PR DESCRIPTION
Ticket: [PAE-1349](https://eaflood.atlassian.net/browse/PAE-1349)
- Always show displaying registration number for non-accredited registrations in reports details section 
- Pass site data to submit page view and conditionally render site row in Your report summary list
- Refactor submit.njk summary list to use idiomatic Nunjucks set/if pattern

[PAE-1349]: https://eaflood.atlassian.net/browse/PAE-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ