### PR TITLE
PAE-1339: Apply HapiRequest typedef to submitted report and upload controllers

### DIFF
--- a/src/server/reports/helpers/format-period-label.js
+++ b/src/server/reports/helpers/format-period-label.js
@@ -2,17 +2,18 @@ import { CADENCE } from '../constants.js'
 
 /**
  * @import { CadenceValue } from '../constants.js'
+ * @import { ReportingPeriod } from './fetch-reporting-periods.js'
  */
 
 /**
- * @import { ReportingPeriod } from './fetch-reporting-periods.js'
+ * @typedef {Pick<ReportingPeriod, 'year' | 'period'>} PeriodRef
  * @typedef {(key: string, params?: Record<string, unknown>) => string} Localise
  */
 
 /**
  * Formats a reporting period into a display label.
  * Monthly: "January 2026", Quarterly: "Quarter 1, 2026"
- * @param {ReportingPeriod} period
+ * @param {PeriodRef} period
  * @param {CadenceValue} cadence
  * @param {Localise} localise
  * @returns {string}
@@ -32,7 +33,7 @@ export function formatPeriodLabel(period, cadence, localise) {
 /**
  * Formats a reporting period into a shorter display label without the year.
  * Monthly: "January", Quarterly: "Quarter 1"
- * @param {ReportingPeriod} period
+ * @param {PeriodRef} period
  * @param {CadenceValue} cadence
  * @param {Localise} localise
  * @returns {string}

--- a/src/server/reports/helpers/period-params-schema.js
+++ b/src/server/reports/helpers/period-params-schema.js
@@ -2,6 +2,21 @@ import Joi from 'joi'
 
 import { CADENCE } from '../constants.js'
 
+/**
+ * @import { CadenceValue } from '../constants.js'
+ */
+
+/**
+ * Shape produced by `periodParamsSchema` after Joi validation.
+ * @typedef {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   year: number,
+ *   cadence: CadenceValue,
+ *   period: number
+ * }} PeriodParams
+ */
+
 const MIN_YEAR = 2024
 const MAX_YEAR = 2100
 const MAX_PERIOD = 12

--- a/src/server/reports/submitted-controller.js
+++ b/src/server/reports/submitted-controller.js
@@ -16,6 +16,10 @@ export const submittedController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -74,5 +78,7 @@ export const submittedController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/summary-log-upload/controller.js
+++ b/src/server/summary-log-upload/controller.js
@@ -7,6 +7,10 @@ import { initiateSummaryLogUpload } from '#server/common/helpers/upload/initiate
  * @satisfies {Partial<ServerRoute>}
  */
 export const summaryLogUploadController = {
+  /**
+   * @param {HapiRequest & { params: { organisationId: string, registrationId: string } }} request
+   * @param {ResponseToolkit} h
+   */
   handler: async (request, h) => {
     const localise = request.t
     const { organisationId, registrationId } = request.params
@@ -68,5 +72,6 @@ export const summaryLogUploadController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
Another incremental slice of PAE-1339. Clears 12 `npm run lint:types` errors (375 → 363) by applying the `HapiRequest` JSDoc typedef introduced in #768 to two more handlers, plus a small follow-on correction to `formatPeriodLabel`.

## What changed

- `src/server/reports/submitted-controller.js` — handler annotated with `HapiRequest & { params: PeriodParams }` so `request.t`, `request.localiseUrl`, and the Joi-validated params stop being `unknown`/missing.
- `src/server/summary-log-upload/controller.js` — handler annotated with `HapiRequest & { params: { organisationId: string, registrationId: string } }`. Inline params typedef kept local for now; a shared `RegistrationRef` can wait until more handlers need it.
- `src/server/reports/helpers/period-params-schema.js` — adds a `PeriodParams` typedef co-located with the Joi schema it mirrors, so any handler validating with this schema can intersect it into its `request.params` shape.
- `src/server/reports/helpers/format-period-label.js` — narrows `formatPeriodLabel` and `formatPeriodShort` param types from `ReportingPeriod` to `Pick<ReportingPeriod, 'year' | 'period'>` (aliased as `PeriodRef`). Both functions only read `year` and `period`; the previous signature was over-claiming fields it never touched, forcing callers to fabricate unused dates or route through the checker via holes. The narrower contract matches what the functions actually use and is assignable-from full `ReportingPeriod`, so no caller breaks.

## Why

PAE-1339 tracks pre-existing type errors in epr-frontend; PR #765 made `lint:types` advisory in CI, #768 introduced the `HapiRequest` pattern. The bead is split across many PRs so each slice is easy to review and lands clean. This slice picks the smaller controllers that use `periodParamsSchema` or a simple org/registration params pair.

No `.ts`/`.tsx`/`.d.ts` files added. No `any` casts, no `@ts-expect-error`, no new runtime null guards.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ