### PR TITLE
PAE-1344: Allow save and come back later with empty input fields

### DIFF
--- a/src/server/reports/exporter/free-perns-controller.test.js
+++ b/src/server/reports/exporter/free-perns-controller.test.js
@@ -346,6 +346,71 @@ describe('#freePernController', () => {
             `/organisations/${organisationId}/registrations/${registrationId}/reports`
           )
         })
+
+        it('should redirect to reports list when freeTonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { statusCode, headers } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: '', action: 'save' }
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toBe(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
+        })
+
+        it('should not call updateReport when freeTonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: '', action: 'save' }
+          })
+
+          expect(updateReport).not.toHaveBeenCalled()
+        })
+
+        it('should show error when freeTonnage is non-numeric', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { result } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: 'abc', action: 'save' }
+          })
+
+          const { body } = new JSDOM(result).window.document
+          const alert = getByRole(body, 'alert')
+
+          expect(
+            getByText(
+              alert,
+              /Enter the total tonnage in digits, using only a whole number/
+            )
+          ).toBeDefined()
+        })
       })
 
       describe('validation errors', () => {

--- a/src/server/reports/exporter/prn-summary-controller.test.js
+++ b/src/server/reports/exporter/prn-summary-controller.test.js
@@ -368,6 +368,71 @@ describe('#prnSummaryController', () => {
             `/organisations/${organisationId}/registrations/${registrationId}/reports`
           )
         })
+
+        it('should redirect to reports list when revenue is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { statusCode, headers } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, prnRevenue: '', action: 'save' }
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toBe(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
+        })
+
+        it('should not call updateReport when revenue is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, prnRevenue: '', action: 'save' }
+          })
+
+          expect(updateReport).not.toHaveBeenCalled()
+        })
+
+        it('should show error when revenue is non-numeric', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { result } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, prnRevenue: 'abc', action: 'save' }
+          })
+
+          const { body } = new JSDOM(result).window.document
+          const alert = getByRole(body, 'alert')
+
+          expect(
+            getByText(
+              alert,
+              /Enter the total revenue in digits, using a decimal point if needed/
+            )
+          ).toBeDefined()
+        })
       })
 
       describe('validation errors', () => {

--- a/src/server/reports/exporter/tonnes-not-exported-controller.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.js
@@ -36,15 +36,17 @@ const { getController, postController } = createDataPageControllers({
       const { tonnageNotExported, action } = request.payload
       const session = request.auth.credentials
 
-      await updateReport(
-        organisationId,
-        registrationId,
-        year,
-        cadence,
-        period,
-        { tonnageNotExported },
-        session.idToken
-      )
+      if (tonnageNotExported !== undefined) {
+        await updateReport(
+          organisationId,
+          registrationId,
+          year,
+          cadence,
+          period,
+          { tonnageNotExported },
+          session.idToken
+        )
+      }
 
       return h.redirect(
         getRedirectUrl(

--- a/src/server/reports/exporter/tonnes-not-exported-controller.test.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.test.js
@@ -260,6 +260,68 @@ describe('#tonnesNotExportedController', () => {
         )
       })
 
+      it('should redirect to reports list when save is clicked with empty tonnage', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, quarterlyUrl, {
+          auth: mockAuth
+        })
+
+        const { statusCode, headers } = await server.inject({
+          method: 'POST',
+          url: quarterlyUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, tonnageNotExported: '', action: 'save' }
+        })
+
+        expect(statusCode).toBe(statusCodes.found)
+        expect(headers.location).toBe(
+          `/organisations/${organisationId}/registrations/${registrationId}/reports`
+        )
+      })
+
+      it('should not call updateReport when save is clicked with empty tonnage', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, quarterlyUrl, {
+          auth: mockAuth
+        })
+
+        await server.inject({
+          method: 'POST',
+          url: quarterlyUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, tonnageNotExported: '', action: 'save' }
+        })
+
+        expect(updateReport).not.toHaveBeenCalled()
+      })
+
+      it('should show error when save is clicked with non-numeric tonnage', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, quarterlyUrl, {
+          auth: mockAuth
+        })
+
+        const { result } = await server.inject({
+          method: 'POST',
+          url: quarterlyUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, tonnageNotExported: 'abc', action: 'save' }
+        })
+
+        const { body } = new JSDOM(result).window.document
+        const alert = getByRole(body, 'alert')
+
+        expect(alert.textContent).toContain(
+          'Enter the total tonnage in digits, using a decimal point if needed'
+        )
+      })
+
       it('should call updateReport with tonnageNotExported', async ({
         server
       }) => {

--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -130,17 +130,20 @@ function createSimplePostHandler(fieldName, nextPage) {
   return async (request, h) => {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
+    const fieldValue = request.payload[fieldName]
     const session = request.auth.credentials
 
-    await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      { [fieldName]: request.payload[fieldName] },
-      session.idToken
-    )
+    if (fieldValue !== undefined) {
+      await updateReport(
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        { [fieldName]: fieldValue },
+        session.idToken
+      )
+    }
 
     return h.redirect(
       getRedirectUrl(request, request.params, request.payload.action, nextPage)
@@ -170,6 +173,17 @@ function createTonnagePostHandler(
       request.params
     const fieldValue = request.payload[fieldName]
     const session = request.auth.credentials
+
+    if (fieldValue === undefined) {
+      return h.redirect(
+        getRedirectUrl(
+          request,
+          request.params,
+          request.payload.action,
+          nextPage
+        )
+      )
+    }
 
     const reportDetail = await fetchReportDetail(
       organisationId,

--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -187,7 +187,9 @@ function createTonnagePostHandler(
   return async (request, h) => {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
-    const fieldValue = /** @type {number} */ (request.payload[fieldName])
+    const fieldValue = /** @type {number | undefined} */ (
+      request.payload[fieldName]
+    )
     const session = request.auth.credentials
 
     if (fieldValue === undefined) {

--- a/src/server/reports/helpers/validation.js
+++ b/src/server/reports/helpers/validation.js
@@ -42,7 +42,7 @@ export const revenuePayloadSchema = Joi.object({
     .empty('')
     .min(0)
     .custom(maxTwoDecimalPlaces)
-    .required()
+    .when('action', { is: 'continue', then: Joi.required() })
     .messages({
       'any.required': revenueErrors.required,
       'number.base': revenueErrors.format,
@@ -67,7 +67,7 @@ export const tonnageRecycledPayloadSchema = Joi.object({
     .empty('')
     .min(0)
     .custom(maxTwoDecimalPlaces)
-    .required()
+    .when('action', { is: 'continue', then: Joi.required() })
     .messages({
       'any.required': tonnageRecycledErrors.required,
       'number.base': tonnageRecycledErrors.format,
@@ -92,7 +92,7 @@ export const tonnageNotRecycledPayloadSchema = Joi.object({
     .empty('')
     .min(0)
     .custom(maxTwoDecimalPlaces)
-    .required()
+    .when('action', { is: 'continue', then: Joi.required() })
     .messages({
       'any.required': tonnageNotRecycledErrors.required,
       'number.base': tonnageNotRecycledErrors.format,
@@ -117,7 +117,7 @@ export const tonnageNotExportedPayloadSchema = Joi.object({
     .empty('')
     .min(0)
     .custom(maxTwoDecimalPlaces)
-    .required()
+    .when('action', { is: 'continue', then: Joi.required() })
     .messages({
       'any.required': tonnageNotExportedErrors.required,
       'number.base': tonnageNotExportedErrors.format,
@@ -137,14 +137,19 @@ const freeTonnageErrors = Object.freeze({
 })
 
 export const freeTonnagePayloadSchema = Joi.object({
-  freeTonnage: Joi.number().empty('').integer().min(0).required().messages({
-    'any.required': freeTonnageErrors.required,
-    'number.base': freeTonnageErrors.format,
-    'number.integer': freeTonnageErrors.format,
-    'number.min': freeTonnageErrors.negative,
-    'number.unsafe': freeTonnageErrors.format,
-    'number.infinity': freeTonnageErrors.format
-  }),
+  freeTonnage: Joi.number()
+    .empty('')
+    .integer()
+    .min(0)
+    .when('action', { is: 'continue', then: Joi.required() })
+    .messages({
+      'any.required': freeTonnageErrors.required,
+      'number.base': freeTonnageErrors.format,
+      'number.integer': freeTonnageErrors.format,
+      'number.min': freeTonnageErrors.negative,
+      'number.unsafe': freeTonnageErrors.format,
+      'number.infinity': freeTonnageErrors.format
+    }),
   action: Joi.string().valid('continue', 'save').required(),
   crumb: Joi.string()
 })

--- a/src/server/reports/prn-summary-dispatcher.js
+++ b/src/server/reports/prn-summary-dispatcher.js
@@ -69,7 +69,7 @@ export const prnSummaryDispatchPostController = {
       'prn-summary dispatch POST'
     )
 
-    const { error } = controller.options.validate.payload.validate(
+    const { error, value } = controller.options.validate.payload.validate(
       request.payload,
       { abortEarly: false }
     )
@@ -82,6 +82,7 @@ export const prnSummaryDispatchPostController = {
       return controller.options.validate.failAction(request, h, error)
     }
 
+    request.payload = value
     return controller.handler(request, h)
   }
 }

--- a/src/server/reports/reprocessor/free-prns-controller.test.js
+++ b/src/server/reports/reprocessor/free-prns-controller.test.js
@@ -326,6 +326,71 @@ describe('#reprocessorFreePrnsController', () => {
             `/organisations/${organisationId}/registrations/${registrationId}/reports`
           )
         })
+
+        it('should redirect to reports list when freeTonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { statusCode, headers } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: '', action: 'save' }
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toBe(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
+        })
+
+        it('should not call updateReport when freeTonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: '', action: 'save' }
+          })
+
+          expect(updateReport).not.toHaveBeenCalled()
+        })
+
+        it('should show error when freeTonnage is non-numeric', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { result } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, freeTonnage: 'abc', action: 'save' }
+          })
+
+          const { body } = new JSDOM(result).window.document
+          const alert = getByRole(body, 'alert')
+
+          expect(
+            getByText(
+              alert,
+              /Enter the total tonnage in digits, using only a whole number/
+            )
+          ).toBeDefined()
+        })
       })
 
       describe('validation errors', () => {

--- a/src/server/reports/reprocessor/prn-summary-controller.test.js
+++ b/src/server/reports/reprocessor/prn-summary-controller.test.js
@@ -279,6 +279,71 @@ describe('#reprocessorPrnSummaryController', () => {
         )
       })
 
+      it('should redirect to reports list when save is clicked with empty revenue', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+          auth: mockAuth
+        })
+
+        const { statusCode, headers } = await server.inject({
+          method: 'POST',
+          url: baseUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, prnRevenue: '', action: 'save' }
+        })
+
+        expect(statusCode).toBe(statusCodes.found)
+        expect(headers.location).toBe(
+          `/organisations/${organisationId}/registrations/${registrationId}/reports`
+        )
+      })
+
+      it('should not call updateReport when save is clicked with empty revenue', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+          auth: mockAuth
+        })
+
+        await server.inject({
+          method: 'POST',
+          url: baseUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, prnRevenue: '', action: 'save' }
+        })
+
+        expect(updateReport).not.toHaveBeenCalled()
+      })
+
+      it('should show error when save is clicked with non-numeric revenue', async ({
+        server
+      }) => {
+        const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+          auth: mockAuth
+        })
+
+        const { result } = await server.inject({
+          method: 'POST',
+          url: baseUrl,
+          auth: mockAuth,
+          headers: { cookie },
+          payload: { crumb, prnRevenue: 'abc', action: 'save' }
+        })
+
+        const { body } = new JSDOM(result).window.document
+        const alert = getByRole(body, 'alert')
+
+        expect(
+          getByText(
+            alert,
+            /Enter the total revenue in digits, using a decimal point if needed/
+          )
+        ).toBeDefined()
+      })
+
       it('should show error when revenue has more than 2 decimal places', async ({
         server
       }) => {

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.js
@@ -36,15 +36,17 @@ const { getController, postController } = createDataPageControllers({
       const { tonnageNotRecycled, action } = request.payload
       const session = request.auth.credentials
 
-      await updateReport(
-        organisationId,
-        registrationId,
-        year,
-        cadence,
-        period,
-        { tonnageNotRecycled },
-        session.idToken
-      )
+      if (tonnageNotRecycled !== undefined) {
+        await updateReport(
+          organisationId,
+          registrationId,
+          year,
+          cadence,
+          period,
+          { tonnageNotRecycled },
+          session.idToken
+        )
+      }
 
       const nextPage =
         cadence === CADENCE.MONTHLY ? 'prn-summary' : 'supporting-information'

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
@@ -289,6 +289,71 @@ describe('#tonnesNotRecycledController', () => {
             `/organisations/${organisationId}/registrations/${registrationId}/reports`
           )
         })
+
+        it('should redirect to reports list when tonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, monthlyUrl, {
+            auth: mockAuth
+          })
+
+          const { statusCode, headers } = await server.inject({
+            method: 'POST',
+            url: monthlyUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageNotRecycled: '', action: 'save' }
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toBe(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
+        })
+
+        it('should not call updateReport when tonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, monthlyUrl, {
+            auth: mockAuth
+          })
+
+          await server.inject({
+            method: 'POST',
+            url: monthlyUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageNotRecycled: '', action: 'save' }
+          })
+
+          expect(updateReport).not.toHaveBeenCalled()
+        })
+
+        it('should show error when tonnage is non-numeric', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, monthlyUrl, {
+            auth: mockAuth
+          })
+
+          const { result } = await server.inject({
+            method: 'POST',
+            url: monthlyUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageNotRecycled: 'abc', action: 'save' }
+          })
+
+          const { body } = new JSDOM(result).window.document
+          const alert = getByRole(body, 'alert')
+
+          expect(
+            getByText(
+              alert,
+              /Enter the total tonnage in digits, using a decimal point if needed/
+            )
+          ).toBeDefined()
+        })
       })
 
       describe('validation errors', () => {

--- a/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
@@ -292,6 +292,71 @@ describe('#tonnesRecycledController', () => {
             `/organisations/${organisationId}/registrations/${registrationId}/reports`
           )
         })
+
+        it('should redirect to reports list when tonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { statusCode, headers } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageRecycled: '', action: 'save' }
+          })
+
+          expect(statusCode).toBe(statusCodes.found)
+          expect(headers.location).toBe(
+            `/organisations/${organisationId}/registrations/${registrationId}/reports`
+          )
+        })
+
+        it('should not call updateReport when tonnage is empty', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageRecycled: '', action: 'save' }
+          })
+
+          expect(updateReport).not.toHaveBeenCalled()
+        })
+
+        it('should show error when tonnage is non-numeric', async ({
+          server
+        }) => {
+          const { cookie, crumb } = await getCsrfToken(server, baseUrl, {
+            auth: mockAuth
+          })
+
+          const { result } = await server.inject({
+            method: 'POST',
+            url: baseUrl,
+            auth: mockAuth,
+            headers: { cookie },
+            payload: { crumb, tonnageRecycled: 'abc', action: 'save' }
+          })
+
+          const { body } = new JSDOM(result).window.document
+          const alert = getByRole(body, 'alert')
+
+          expect(
+            getByText(
+              alert,
+              /Enter the total tonnage in digits, using a decimal point if needed/
+            )
+          ).toBeDefined()
+        })
       })
 
       describe('validation errors', () => {


### PR DESCRIPTION
Ticket: [PAE-1344](https://eaflood.atlassian.net/browse/PAE-1344)
## Summary
Clicking "Save and come back later" on a report data-entry page now returns the operator to the reports list with the report marked "In progress", even when the input field has been left blank. Previously this triggered a required-field validation error on every numeric field (supporting information was the only one that worked as intended).

## What Changed
- Relaxed the required-field rule on tonnage and revenue schemas so it only fires when the operator clicks Continue, not Save.
- Short-circuited the POST handlers (both shared and custom) to skip the backend update when no value has been entered, then redirect straight to the reports list.
- Fixed the PRN summary dispatcher so Joi's coerced payload is passed through to the downstream handler, matching Hapi's default validation behaviour.
- Added unit tests across all seven affected controllers covering three cases: empty + save (redirects without persisting), empty + save (no backend call), and malformed + save (format validation still fires).

## Why
The bug blocked operators from parking a report part-way through and coming back to it later, which is a core part of the reporting journey. Format validation is preserved on save so that garbage input is still rejected; only the "field is required" rule is relaxed, and only for the save action.

[PAE-1344]: https://eaflood.atlassian.net/browse/PAE-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ