### PR TITLE
PAE-1339: Apply HapiRequest typedef to reports list, delete and created controllers

### DIFF
--- a/src/server/reports/created-controller.js
+++ b/src/server/reports/created-controller.js
@@ -17,6 +17,10 @@ export const createdController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -89,5 +93,7 @@ export const createdController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/reports/delete-controller.js
+++ b/src/server/reports/delete-controller.js
@@ -10,6 +10,9 @@ const payloadSchema = Joi.object({
   crumb: Joi.string()
 })
 
+/**
+ * @param {HapiRequest} request
+ */
 function resolveBackUrl(request) {
   const { organisationId, registrationId } = request.params
   const fallback = request.localiseUrl(
@@ -48,6 +51,10 @@ export const deleteGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -86,6 +93,10 @@ export const deletePostController = {
       payload: payloadSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -109,5 +120,7 @@ export const deletePostController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/reports/list-controller.js
+++ b/src/server/reports/list-controller.js
@@ -19,7 +19,7 @@ import {
  * Each row is an array of cell objects ({ text } or { html }).
  * @param {object} options
  * @param {import('./helpers/fetch-reporting-periods.js').ReportingPeriod[]} options.reportingPeriods
- * @param {string} options.cadence
+ * @param {CadenceValue} options.cadence
  * @param {string} options.organisationId
  * @param {string} options.registrationId
  * @param {boolean} options.isAccreditedExporter
@@ -80,6 +80,12 @@ function buildTableRows({
  * @satisfies {Partial<ServerRoute>}
  */
 export const listController = {
+  /**
+   * @param {HapiRequest & {
+   *   params: { organisationId: string, registrationId: string }
+   * }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId } = request.params
     const session = request.auth.credentials
@@ -146,5 +152,7 @@ export const listController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { CadenceValue } from './constants.js'
  */


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Next slice of the incremental type-error fixes for `epr-frontend` (under PAE-1339). Mirrors the pattern from PR #768 (auth entry points) and PR #771 (submitted report + upload controllers): apply the `HapiRequest` JSDoc typedef to tighten route handlers, without introducing any TypeScript, `any` casts, or runtime guards.

- `reports/list-controller.js` — route has base params only, so the handler's params type is `{ organisationId, registrationId }`; `buildTableRows` now takes `CadenceValue` instead of `string` (the real type returned by `fetchReportingPeriods`).
- `reports/delete-controller.js` — both GET and POST handlers intersect `HapiRequest` with `PeriodParams`; the `resolveBackUrl` helper is annotated with plain `HapiRequest`.
- `reports/created-controller.js` — handler annotated to intersect `HapiRequest` with `PeriodParams`.

## Result

`npm run lint:types` error count: **363 → 343** (−20). No errors remain in these three files. No suppressions added, no `.d.ts`, no `any`.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ