### PR TITLE
PAE-1339: Apply HapiRequest typedef across the PRN subsystem

### DIFF
--- a/src/server/common/helpers/prns/registration-helpers.js
+++ b/src/server/common/helpers/prns/registration-helpers.js
@@ -17,7 +17,7 @@ export const isReprocessorRegistration = (registration) =>
 /**
  * Get display names for PRN/PERN based on waste processing type
  * @param {{wasteProcessingType: string}} registration
- * @returns {{isExporter: boolean, noteType: 'PRN' | 'PERN', noteTypePlural: 'PRNs' | 'PERNs', wasteAction: 'export' | 'reprocessing', wasteActionGerund: 'exporting' | 'reprocessing'}}
+ * @returns {{isExporter: boolean, noteType: 'PRN' | 'PERN', noteTypeFull: 'Packaging Waste Export Recycling Note' | 'Packaging Waste Recycling Note', noteTypePlural: 'PRNs' | 'PERNs', wasteAction: 'export' | 'reprocessing', wasteActionGerund: 'exporting' | 'reprocessing'}}
  */
 export const getNoteTypeDisplayNames = (registration) => {
   const isExporter = isExporterRegistration(registration)

--- a/src/server/common/helpers/waste-organisations/get-issued-to-org-display-name.js
+++ b/src/server/common/helpers/waste-organisations/get-issued-to-org-display-name.js
@@ -4,7 +4,11 @@
  * Compliance schemes show tradingName (the scheme name), large producers
  * show name (the legal/registered name). When registrationType is absent,
  * falls back to preferring tradingName over name.
- * @param {Pick<import('./types.js').WasteOrganisation, 'name' | 'tradingName'> & { registrationType?: string }} organisation
+ *
+ * `tradingName` is `?: string | null` to accept both the backend's nullable
+ * shape (WasteOrganisation) and the PRN response's optional shape
+ * (IssuedToOrganisation). The `|| name` fallback handles both cases.
+ * @param {{ name: string, tradingName?: string | null, registrationType?: string }} organisation
  * @returns {string}
  */
 export const getIssuedToOrgDisplayName = (organisation) => {

--- a/src/server/common/helpers/waste-organisations/get-issuing-org-display-name.js
+++ b/src/server/common/helpers/waste-organisations/get-issuing-org-display-name.js
@@ -1,7 +1,11 @@
 /**
  * Gets the display name for an issuing organisation (reprocessor/exporter).
  * Always prefers tradingName over name.
- * @param {Pick<import('./types.js').WasteOrganisation, 'name' | 'tradingName'>} organisation
+ *
+ * `tradingName` is `?: string | null` so the same helper accepts both the
+ * backend's nullable `WasteOrganisation` shape and the PRN response's
+ * optional companyDetails shape. The `|| name` fallback handles both.
+ * @param {{ name: string, tradingName?: string | null }} organisation
  * @returns {string}
  */
 export const getIssuingOrgDisplayName = (organisation) =>

--- a/src/server/prns/action-controller.js
+++ b/src/server/prns/action-controller.js
@@ -16,6 +16,10 @@ import { getDisplayMaterial } from '#server/common/helpers/materials/get-display
  * @satisfies {Partial<ServerRoute>}
  */
 export const actionController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
@@ -67,7 +71,7 @@ export const actionController = {
  * @param {{
  *   accreditation: RegistrationWithAccreditation['accreditation'],
  *   accreditationId: string,
- *   localise: (key: string, params?: object) => string,
+ *   localise: TFunction,
  *   organisationData: RegistrationWithAccreditation['organisationData'],
  *   organisationId: string,
  *   prn: PackagingRecyclingNote,
@@ -75,7 +79,7 @@ export const actionController = {
  *   recipientDisplayName: string,
  *   registration: RegistrationWithAccreditation['registration'],
  *   registrationId: string,
- *   request: Request
+ *   request: HapiRequest
  * }} params
  */
 function buildActionViewData({
@@ -237,7 +241,10 @@ function buildActionPrnDetailRows({
 }
 
 /**
- * @import { Request, ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { TFunction } from 'i18next'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  * @import { RegistrationWithAccreditation } from '#server/common/helpers/organisations/fetch-registration-and-accreditation.js'
  * @import { PackagingRecyclingNote } from './helpers/fetch-packaging-recycling-note.js'
+ * @import { PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/cancel-controller.js
+++ b/src/server/prns/cancel-controller.js
@@ -12,6 +12,10 @@ import { updatePrnStatus } from './helpers/update-prn-status.js'
  * @satisfies {Partial<ServerRoute>}
  */
 export const cancelGetController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { registration, prn, basePath, prnId } =
       await fetchPrnContext(request)
@@ -39,6 +43,10 @@ export const cancelGetController = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const cancelPostController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const {
       organisationId,
@@ -86,5 +94,7 @@ export const cancelPostController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/cancelled-controller.js
+++ b/src/server/prns/cancelled-controller.js
@@ -8,6 +8,10 @@ import {
  * @satisfies {Partial<ServerRoute>}
  */
 export const cancelledController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, registration, prn, basePath } =
       await fetchPrnContext(request)
@@ -42,5 +46,7 @@ export const cancelledController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/controller.js
+++ b/src/server/prns/controller.js
@@ -23,6 +23,10 @@ function buildInsufficientBalanceError(localise) {
  * @satisfies {Partial<ServerRoute>}
  */
 export const controller = {
+  /**
+   * @param {HapiRequest & { params: PrnListParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId } = request.params
     const session = request.auth.credentials
@@ -67,5 +71,7 @@ export const controller = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnListParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/created-controller.js
+++ b/src/server/prns/created-controller.js
@@ -4,12 +4,17 @@ import { getNoteTypeDisplayNames } from '#server/common/helpers/prns/registratio
  * @satisfies {Partial<ServerRoute>}
  */
 export const createdController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
     const { t: localise } = request
 
     // Check for success session data
+    /** @type {PrnCreatedSession | null} */
     const prnCreated = request.yar.get('prnCreated')
 
     if (prnCreated?.id !== prnId) {
@@ -63,5 +68,7 @@ export const createdController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnCreatedSession, PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/delete-controller.js
+++ b/src/server/prns/delete-controller.js
@@ -12,6 +12,10 @@ import { updatePrnStatus } from './helpers/update-prn-status.js'
  * @satisfies {Partial<ServerRoute>}
  */
 export const deleteGetController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { registration, prn, basePath, prnId } =
       await fetchPrnContext(request)
@@ -38,6 +42,10 @@ export const deleteGetController = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const deletePostController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const {
       organisationId,
@@ -77,5 +85,7 @@ export const deletePostController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/discard-controller.js
+++ b/src/server/prns/discard-controller.js
@@ -8,12 +8,17 @@ import { updatePrnStatus } from './helpers/update-prn-status.js'
  * @satisfies {Partial<ServerRoute>}
  */
 export const discardGetController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
     const { t: localise } = request
     const session = request.auth.credentials
 
+    /** @type {PrnDraftSession | null} */
     const prnDraft = request.yar.get('prnDraft')
 
     if (prnDraft?.id !== prnId) {
@@ -48,6 +53,10 @@ export const discardGetController = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const discardPostController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
@@ -55,6 +64,7 @@ export const discardPostController = {
 
     const createUrl = `/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/packaging-recycling-notes/create`
 
+    /** @type {PrnDraftSession | null} */
     const prnDraft = request.yar.get('prnDraft')
 
     if (prnDraft?.id !== prnId) {
@@ -87,5 +97,7 @@ export const discardPostController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams, PrnDraftSession } from './helpers/session-types.js'
  */

--- a/src/server/prns/helpers/create-prn.js
+++ b/src/server/prns/helpers/create-prn.js
@@ -4,7 +4,8 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
  * @typedef {object} IssuedToOrganisation
  * @property {string} id - The recipient organisation ID
  * @property {string} name - The recipient organisation name
- * @property {string} [tradingName] - The recipient organisation trading name
+ * @property {string | null} [tradingName] - The recipient organisation trading name
+ * @property {string} [registrationType] - Producer/compliance scheme classification
  */
 
 /**

--- a/src/server/prns/helpers/fetch-prn-context.js
+++ b/src/server/prns/helpers/fetch-prn-context.js
@@ -36,7 +36,7 @@ function buildPrnBasePath({ organisationId, registrationId, accreditationId }) {
 /**
  * Fetches PRN with registration data for GET handlers.
  * Extracts request params and fetches data in parallel.
- * @param {Request} request
+ * @param {HapiRequest} request
  */
 async function fetchPrnContext(request) {
   const { organisationId, registrationId, accreditationId, prnId } =
@@ -80,7 +80,7 @@ async function fetchPrnContext(request) {
 /**
  * Fetches PRN data for POST handlers that update status.
  * Extracts request params and fetches the PRN.
- * @param {Request} request
+ * @param {HapiRequest} request
  */
 async function fetchPrnForUpdate(request) {
   const { organisationId, registrationId, accreditationId, prnId } =
@@ -120,5 +120,5 @@ export {
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/prns/helpers/session-types.js
+++ b/src/server/prns/helpers/session-types.js
@@ -19,9 +19,14 @@
  * Session data written after a draft PRN is confirmed
  * (status transitions to awaiting_authorisation). Read by
  * createdController to render the success page.
+ *
+ * `prnNumber` is optional because the current writer in viewPostController
+ * does not set it — the backend returns it, but the writer omits it. The
+ * created page therefore renders without a PRN number today. Tracked as a
+ * separate fix; the typedef reflects runtime reality.
  * @typedef {{
  *   id: string,
- *   prnNumber: string | null,
+ *   prnNumber?: string | null,
  *   tonnage: number,
  *   material: string,
  *   status: string,

--- a/src/server/prns/helpers/session-types.js
+++ b/src/server/prns/helpers/session-types.js
@@ -1,0 +1,55 @@
+/**
+ * Session data for a PRN draft, written by postController and
+ * read by discardController, viewController and createdController.
+ * @typedef {{
+ *   id: string,
+ *   tonnage: number,
+ *   tonnageInWords: string,
+ *   material: string,
+ *   status: string,
+ *   recipientName: string,
+ *   notes: string,
+ *   wasteProcessingType: string,
+ *   processToBeUsed: string,
+ *   isDecemberWaste: boolean
+ * }} PrnDraftSession
+ */
+
+/**
+ * Session data written after a draft PRN is confirmed
+ * (status transitions to awaiting_authorisation). Read by
+ * createdController to render the success page.
+ * @typedef {{
+ *   id: string,
+ *   prnNumber: string | null,
+ *   tonnage: number,
+ *   material: string,
+ *   status: string,
+ *   wasteProcessingType: string
+ * }} PrnCreatedSession
+ */
+
+/**
+ * Session data written by issueController to bridge MongoDB replication
+ * lag when issuedController reads the freshly-issued PRN.
+ * @typedef {{
+ *   id: string,
+ *   prnNumber: string | null
+ * }} PrnIssuedSession
+ */
+
+/**
+ * Route params for the PRN list and create endpoints.
+ * @typedef {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string
+ * }} PrnListParams
+ */
+
+/**
+ * Route params for PRN detail endpoints (view, delete, discard, cancel, etc.).
+ * @typedef {PrnListParams & { prnId: string }} PrnDetailParams
+ */
+
+export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/prns/issue-controller.js
+++ b/src/server/prns/issue-controller.js
@@ -5,6 +5,10 @@ import { updatePrnStatus } from './helpers/update-prn-status.js'
  * @satisfies {Partial<ServerRoute>}
  */
 export const issueController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
@@ -47,5 +51,7 @@ export const issueController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/issued-controller.js
+++ b/src/server/prns/issued-controller.js
@@ -7,6 +7,10 @@ import { fetchPackagingRecyclingNote } from './helpers/fetch-packaging-recycling
  * @satisfies {Partial<ServerRoute>}
  */
 export const issuedController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
@@ -16,6 +20,7 @@ export const issuedController = {
     // Read and clear session data stored by issue controller.
     // This mitigates a MongoDB replication lag race condition where the
     // freshly-issued prnNumber may not yet be available via the fetch below.
+    /** @type {PrnIssuedSession | null} */
     const prnIssued = request.yar.get('prnIssued')
     if (prnIssued) {
       request.yar.clear('prnIssued')
@@ -87,5 +92,7 @@ export const issuedController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnDetailParams, PrnIssuedSession } from './helpers/session-types.js'
  */

--- a/src/server/prns/list-controller.js
+++ b/src/server/prns/list-controller.js
@@ -31,6 +31,10 @@ const filterPrnsByStatuses = (prns, statuses) =>
  * @satisfies {Partial<ServerRoute>}
  */
 export const listController = {
+  /**
+   * @param {HapiRequest & { params: PrnListParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId } = request.params
     const session = request.auth.credentials
@@ -83,5 +87,7 @@ export const listController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PrnListParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/post-controller.js
+++ b/src/server/prns/post-controller.js
@@ -42,6 +42,20 @@ const payloadSchema = Joi.object({
 })
 
 /**
+ * Create-PRN form payload after Joi validation. `tonnage` arrives as a
+ * string from the form and is coerced to a number when calling createPrn.
+ * `failAction` runs before Joi coercion too, so the typing on failAction's
+ * payload is intentionally the unvalidated shape.
+ * @typedef {{
+ *   tonnage: string,
+ *   recipient: string,
+ *   notes?: string,
+ *   nation: string,
+ *   wasteProcessingType: string
+ * }} CreatePrnPayload
+ */
+
+/**
  * @param {import('joi').ValidationErrorItem} detail
  * @returns {string}
  */
@@ -101,9 +115,9 @@ function buildValidationErrors(validationError, localise, wasteProcessingType) {
 }
 
 /**
- * @param {object} result - The created PRN draft from the backend
+ * @param {CreatePrnResponse} result - The created PRN draft from the backend
  * @param {string} recipientDisplayName - The resolved display name for the recipient
- * @param {string} notes - Issuer notes
+ * @param {string | undefined} notes - Issuer notes
  */
 function buildPrnDraftSession(result, recipientDisplayName, notes) {
   return {
@@ -123,6 +137,9 @@ function buildPrnDraftSession(result, recipientDisplayName, notes) {
 /**
  * Re-render the create form when the selected recipient is not
  * found in the organisations list.
+ * @param {HapiRequest & { params: PrnListParams, payload: CreatePrnPayload }} request
+ * @param {ResponseToolkit} h
+ * @param {Array<WasteOrganisation>} organisations
  */
 async function handleInvalidRecipient(request, h, organisations) {
   const { organisationId, registrationId, accreditationId } = request.params
@@ -179,6 +196,12 @@ export const postController = {
   options: {
     validate: {
       payload: payloadSchema,
+      /**
+       * @param {HapiRequest & { params: PrnListParams, payload: CreatePrnPayload }} request
+       * @param {ResponseToolkit} h
+       * @param {Error | undefined} error Hapi's failAction contract — with
+       *   payload validation configured this is always the Joi ValidationError.
+       */
       failAction: async (request, h, error) => {
         const { organisationId, registrationId, accreditationId } =
           request.params
@@ -186,7 +209,7 @@ export const postController = {
 
         const { t: localise } = request
         const { errors, errorSummary } = buildValidationErrors(
-          error,
+          /** @type {Joi.ValidationError} */ (error),
           localise,
           request.payload.wasteProcessingType
         )
@@ -228,6 +251,10 @@ export const postController = {
       }
     }
   },
+  /**
+   * @param {HapiRequest & { params: PrnListParams, payload: CreatePrnPayload }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId } = request.params
     const session = request.auth.credentials
@@ -288,5 +315,9 @@ export const postController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { WasteOrganisation } from '#server/common/helpers/waste-organisations/types.js'
+ * @import { CreatePrnResponse } from './helpers/create-prn.js'
+ * @import { PrnListParams } from './helpers/session-types.js'
  */

--- a/src/server/prns/view-controller.js
+++ b/src/server/prns/view-controller.js
@@ -20,6 +20,10 @@ import { getDisplayMaterial } from '#server/common/helpers/materials/get-display
  * @satisfies {Partial<ServerRoute>}
  */
 export const viewController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
@@ -27,6 +31,7 @@ export const viewController = {
     const session = request.auth.credentials
 
     // Check for draft PRN data in session (creation flow)
+    /** @type {PrnDraftSession | null} */
     const prnDraft = request.yar.get('prnDraft')
 
     if (prnDraft?.id === prnId) {
@@ -57,12 +62,17 @@ export const viewController = {
  * @satisfies {Partial<ServerRoute>}
  */
 export const viewPostController = {
+  /**
+   * @param {HapiRequest & { params: PrnDetailParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, accreditationId, prnId } =
       request.params
     const session = request.auth.credentials
 
     // Retrieve draft PRN data from session
+    /** @type {PrnDraftSession | null} */
     const prnDraft = request.yar.get('prnDraft')
 
     if (prnDraft?.id !== prnId) {
@@ -146,15 +156,16 @@ export const viewPostController = {
 
 /**
  * Handle viewing a draft PRN (creation flow)
- * @param {object} request
- * @param {object} h
- * @param {object} params
- * @param {string} params.organisationId
- * @param {string} params.registrationId
- * @param {string} params.accreditationId
- * @param {object} params.prnDraft
- * @param {(key: string) => string} params.localise
- * @param {object} params.session
+ * @param {HapiRequest} request
+ * @param {ResponseToolkit} h
+ * @param {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string,
+ *   prnDraft: PrnDraftSession,
+ *   localise: TFunction,
+ *   session: UserSession
+ * }} params
  */
 async function handleDraftView(
   request,
@@ -223,15 +234,16 @@ async function handleDraftView(
 
 /**
  * Handle viewing an existing PRN (from backend)
- * @param {object} request
- * @param {object} h
- * @param {object} params
- * @param {string} params.organisationId
- * @param {string} params.registrationId
- * @param {string} params.accreditationId
- * @param {string} params.prnId
- * @param {(key: string) => string} params.localise
- * @param {object} params.session
+ * @param {HapiRequest} request
+ * @param {ResponseToolkit} h
+ * @param {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string,
+ *   prnId: string,
+ *   localise: TFunction,
+ *   session: UserSession
+ * }} params
  */
 async function handleExistingView(
   request,
@@ -312,19 +324,21 @@ async function handleExistingView(
 
 /**
  * Builds the view data object for an existing PRN
- * @param {object} params
- * @param {object} params.prn - PRN data from backend
- * @param {string} params.noteType - 'PRN' or 'PERN'
- * @param {string} params.wasteAction - 'export' or 'reprocessing'
- * @param {boolean} params.isNotDraft - Whether the PRN is not a draft
- * @param {Array} params.prnDetailRows - PRN detail summary rows
- * @param {Array} params.accreditationRows - Accreditation summary rows
- * @param {string} params.backUrl - Back link URL
- * @param {(key: string, params?: object) => string} params.localise - Translation function
- * @param {object} params.request - Hapi request object
- * @param {string} params.organisationId
- * @param {string} params.registrationId
- * @param {string} params.accreditationId
+ * @param {{
+ *   prn: PackagingRecyclingNote,
+ *   noteType: string,
+ *   noteTypeFull: string,
+ *   wasteAction: string,
+ *   isNotDraft: boolean,
+ *   prnDetailRows: Array<object>,
+ *   accreditationRows: Array<object>,
+ *   backUrl: string,
+ *   localise: TFunction,
+ *   request: HapiRequest,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   accreditationId: string
+ * }} params
  * @returns {object} View data object
  */
 function buildExistingPrnViewData({
@@ -370,10 +384,11 @@ function buildExistingPrnViewData({
 
 /**
  * Builds the PRN/PERN details rows for a draft PRN (creation flow)
- * @param {object} params
- * @param {object} params.prnDraft - Draft PRN data from session
- * @param {(key: string) => string} params.localise - Translation function
- * @param {object} params.organisationData - Organisation data
+ * @param {{
+ *   prnDraft: PrnDraftSession,
+ *   localise: TFunction,
+ *   organisationData: { companyDetails?: { name: string, tradingName?: string | null, registrationType?: string } }
+ * }} params
  * @returns {Array} Summary list rows
  */
 function buildDraftPrnDetailRows({ prnDraft, localise, organisationData }) {
@@ -465,5 +480,10 @@ function buildExistingPrnDetailRows({
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { TFunction } from 'i18next'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { UserSession } from '#server/auth/types/session.js'
+ * @import { PackagingRecyclingNote } from './helpers/fetch-packaging-recycling-note.js'
+ * @import { PrnDetailParams, PrnDraftSession } from './helpers/session-types.js'
  */

--- a/src/server/prns/view-data.js
+++ b/src/server/prns/view-data.js
@@ -5,7 +5,7 @@ import { getDisplayMaterial } from '#server/common/helpers/materials/get-display
 
 /**
  * Build view data for the create PRN/PERN page
- * @param {Request} request
+ * @param {HapiRequest} request
  * @param {object} options
  * @param {string} options.organisationId
  * @param {string} options.registrationId
@@ -73,5 +73,5 @@ export function buildCreatePrnViewData(
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Drives `src/server/prns/**/*.js` to zero type errors under `npm run lint:types` (was 77 errors across 13 files). Continues the incremental type-annotation work from #768 and #771 by taking the whole PRN subsystem as a single coherent slice.

## What changed

- **New typedefs in `src/server/prns/helpers/session-types.js`**:
  - `PrnListParams` and `PrnDetailParams` for route path params
  - `PrnDraftSession`, `PrnCreatedSession`, `PrnIssuedSession` for yar session payloads
- **`CreatePrnPayload` typedef** in `post-controller.js` for the Joi-validated create form.
- **Every PRN controller handler** is now annotated with `HapiRequest` intersected with the relevant params/payload shape. Helper functions that accept a request (`fetchPrnContext`, `fetchPrnForUpdate`, `buildCreatePrnViewData`) switched from `Request` to `HapiRequest`.
- **Inner helper JSDoc in `view-controller.js`** updated: `handleDraftView`, `handleExistingView`, `buildExistingPrnViewData`, and `buildDraftPrnDetailRows` use `TFunction` from i18next and the new typedefs instead of hand-rolled `(key: string) => string` and `object` fallbacks.
- **`getNoteTypeDisplayNames`** return type updated to include `noteTypeFull` — the function always returned it but the JSDoc omitted it.
- **`getIssuedToOrgDisplayName` and `getIssuingOrgDisplayName`** widened to `{ name: string, tradingName?: string | null, registrationType?: string }` so both the backend's `WasteOrganisation` (nullable) and the PRN response's `IssuedToOrganisation` (optional) callers satisfy them. The `|| name` fallback already handles `undefined` at runtime.
- **`IssuedToOrganisation` in `create-prn.js`** widened to `tradingName?: string | null` and added optional `registrationType?: string` to match the wire format the backend returns.
- **`failAction` error in `post-controller.js`** cast to `Joi.ValidationError` per Hapi's contract when payload validation is configured.

## Why

The earlier PRs in this series took small bites (one or two controllers) to establish the pattern. The pattern is now well-understood and the PRN subsystem shares helpers between all 13 controllers, so splitting it further would have thrashed the shared files (`session-types.js`, the two display-name helpers, `registration-helpers.js`) across many PRs. Doing the whole subsystem in one go keeps the helpers consistent.

## Note

`PrnCreatedSession.prnNumber` is marked optional in the typedef because the writer in `viewPostController` omits it — the created page renders without a PRN number today. Fixing the writer is tracked separately.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ