### PR TITLE
PAE-1339: Apply HapiRequest typedef across the reports subsystem

### DIFF
--- a/src/server/reports/check-controller.js
+++ b/src/server/reports/check-controller.js
@@ -87,7 +87,17 @@ function buildWasteSentOn(wasteSent) {
 }
 
 /**
- * @param {{ registration: object, accreditation: object|undefined, reportDetail: object, basePath: string, localise: (key: string, params?: object) => string, localiseUrl: (path: string) => string }} params
+ * @param {{
+ *   registration: object,
+ *   accreditation: object|undefined,
+ *   reportDetail: ReportDetailResponse,
+ *   basePath: string,
+ *   localise: (key: string, params?: object) => string,
+ *   localiseUrl: (path: string) => string,
+ *   material: string,
+ *   periodLabel: string,
+ *   cadenceLabel: string
+ * }} params
  * @returns {object}
  */
 function buildCheckViewData({
@@ -174,6 +184,10 @@ export const checkGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -196,7 +210,7 @@ export const checkGetController = {
       session.idToken
     )
 
-    if (reportDetail.status.currentStatus !== SUBMISSION_STATUS.IN_PROGRESS) {
+    if (reportDetail.status?.currentStatus !== SUBMISSION_STATUS.IN_PROGRESS) {
       return h.redirect(
         request.localiseUrl(
           `/organisations/${organisationId}/registrations/${registrationId}/reports`
@@ -235,6 +249,13 @@ export const checkPostController = {
       payload: versionedPayloadSchema
     }
   },
+  /**
+   * @param {HapiRequest & {
+   *   params: PeriodParams,
+   *   payload: VersionedPayload
+   * }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -262,5 +283,9 @@ export const checkPostController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
+ * @import { VersionedPayload } from './helpers/versioned-payload-schema.js'
+ * @import { ReportDetailResponse } from './helpers/fetch-report-detail.js'
  */

--- a/src/server/reports/create-controller.js
+++ b/src/server/reports/create-controller.js
@@ -18,6 +18,10 @@ export const createController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -75,5 +79,7 @@ export const createController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/reports/detail-controller.js
+++ b/src/server/reports/detail-controller.js
@@ -179,6 +179,10 @@ export const detailController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -225,5 +229,7 @@ export const detailController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/reports/exporter/exporter-page-guards.js
+++ b/src/server/reports/exporter/exporter-page-guards.js
@@ -42,8 +42,10 @@ export async function fetchGuardedExporterData(request) {
     throw Boom.notFound()
   }
 
-  const status = reportDetail.status?.currentStatus ?? reportDetail.status
-  if (!reportDetail.id || status !== 'in_progress') {
+  if (
+    !reportDetail.id ||
+    reportDetail.status?.currentStatus !== 'in_progress'
+  ) {
     throw Boom.notFound()
   }
 

--- a/src/server/reports/exporter/exporter-page-guards.js
+++ b/src/server/reports/exporter/exporter-page-guards.js
@@ -14,8 +14,8 @@ import {
  * Fetches registration/accreditation and report detail, then enforces the
  * exporter guard (any cadence). Returns validated data for pages available
  * to all exporters.
- * @param {Request} request
- * @returns {Promise<{ registration: object, accreditation: object | undefined, reportDetail: object }>}
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @returns {Promise<{ registration: object, accreditation: object | undefined, reportDetail: ReportDetailResponse }>}
  */
 export async function fetchGuardedExporterData(request) {
   const { organisationId, registrationId, year, cadence, period } =
@@ -54,8 +54,8 @@ export async function fetchGuardedExporterData(request) {
  * Fetches registration/accreditation and report detail, then enforces the
  * accredited-exporter-monthly guard. Returns validated data for pages
  * available only to accredited exporters (prn-summary, free-perns).
- * @param {Request} request
- * @returns {Promise<{ registration: object, accreditation: object, reportDetail: object }>}
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @returns {Promise<{ registration: object, accreditation: object, reportDetail: ReportDetailResponse }>}
  */
 export async function fetchGuardedAccreditedExporterData(request) {
   const { registration, accreditation, reportDetail } =
@@ -78,8 +78,18 @@ export async function fetchGuardedAccreditedExporterData(request) {
  * Fetches guarded exporter data and builds the common view data fields
  * shared by exporter pages. Page-specific fields are merged from the
  * callback return value.
- * @param {Request} request
- * @param {(ctx: { registration: object, accreditation: object | undefined, reportDetail: object, material: string, periodLabel: string, periodPath: string, reportsListPath: string }) => object} buildPageFields
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @param {(ctx: {
+ *   registration: object,
+ *   accreditation: object | undefined,
+ *   reportDetail: ReportDetailResponse,
+ *   material: string,
+ *   periodLabel: string,
+ *   periodShort: string,
+ *   periodPath: string,
+ *   reportsListPath: string,
+ *   period: number
+ * }) => { backUrl?: string, defaultValue?: unknown, [key: string]: unknown }} buildPageFields
  * @param {object} [options]
  * @param {boolean} [options.accreditedOnly] - Use accredited guard (prn-summary, free-perns)
  * @param {boolean} [options.registeredOnly] - Restrict to registered-only exporters (tonnes-not-exported)
@@ -133,5 +143,7 @@ export async function buildExporterViewData(
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from '../helpers/period-params-schema.js'
+ * @import { ReportDetailResponse } from '../helpers/fetch-report-detail.js'
  */

--- a/src/server/reports/exporter/free-perns-controller.test.js
+++ b/src/server/reports/exporter/free-perns-controller.test.js
@@ -59,7 +59,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 80.25,
@@ -247,7 +247,7 @@ describe('#freePernController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/exporter/prn-summary-controller.test.js
+++ b/src/server/reports/exporter/prn-summary-controller.test.js
@@ -67,7 +67,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 80.25,
@@ -269,7 +269,7 @@ describe('#prnSummaryController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/exporter/tonnes-not-exported-controller.test.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.test.js
@@ -51,7 +51,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 100,
@@ -163,7 +163,7 @@ describe('#tonnesNotExportedController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/helpers/build-table-rows.js
+++ b/src/server/reports/helpers/build-table-rows.js
@@ -29,8 +29,8 @@ export function buildSupplierRows(suppliers) {
 /**
  * Build govukTable rows for supplier details with contact information.
  * Used on review/submit pages where contact details replace tonnage.
- * @param {Array<{supplierName: string, facilityType: string, supplierAddress: string, supplierPhone: string|null, supplierEmail: string|null}>} suppliers
- * @returns {Array<Array<{text: string}>>}
+ * @param {Array<{supplierName: string, facilityType: string, supplierAddress: string | null, supplierPhone: string | null, supplierEmail: string | null}>} suppliers
+ * @returns {Array<Array<{text: string | null}>>}
  */
 export function buildSupplierDetailRows(suppliers) {
   return suppliers.map((supplier) => [
@@ -45,7 +45,7 @@ export function buildSupplierDetailRows(suppliers) {
 /**
  * Build govukTable rows for destination details.
  * @param {Array<{recipientName: string, facilityType: string, tonnageSentOn: number}>} finalDestinations
- * @returns {Array<Array<{text: string | number}>>}
+ * @returns {Array<Array<{text: string}>>}
  */
 export function buildDestinationRows(finalDestinations) {
   return finalDestinations.map((finalDestination) => [
@@ -58,7 +58,7 @@ export function buildDestinationRows(finalDestinations) {
 /**
  * Build govukTable rows for destinations with address.
  * @param {Array<{recipientName: string, facilityType: string, address: string, tonnageSentOn: number}>} finalDestinations
- * @returns {Array<Array<{text: string | number}>>}
+ * @returns {Array<Array<{text: string}>>}
  */
 export function buildDestinationDetailRows(finalDestinations) {
   return finalDestinations.map((destination) => [
@@ -73,7 +73,7 @@ export function buildDestinationDetailRows(finalDestinations) {
  * Build govukTable rows for overseas reprocessing sites.
  * @param {Array<{siteName: string, orsId: string, country: string|null, approved: boolean}>} overseasSites
  * @param {{ showApprovalColumn?: boolean }} [options]
- * @returns {Array<Array<{text: string}>>}
+ * @returns {Array<Array<{text: string | null}>>}
  */
 export function buildOverseasSiteRows(overseasSites, options) {
   return overseasSites.map((overseasSite) => {
@@ -95,7 +95,7 @@ export function buildOverseasSiteRows(overseasSites, options) {
  * Build govukTable rows for overseas sites with tonnage exported and country.
  * @param {Array<{siteName: string, tonnageExported: number, orsId: string, country: string|null, approved: boolean}>} overseasSites
  * @param {{ showApprovalColumn?: boolean }} [options]
- * @returns {Array<Array<{text: string | number}>>}
+ * @returns {Array<Array<{text: string | null}>>}
  */
 export function buildOverseasSiteDetailRows(overseasSites, options) {
   return overseasSites.map((overseasSite) => {

--- a/src/server/reports/helpers/build-table-rows.js
+++ b/src/server/reports/helpers/build-table-rows.js
@@ -44,8 +44,8 @@ export function buildSupplierDetailRows(suppliers) {
 
 /**
  * Build govukTable rows for destination details.
- * @param {Array<{recipientName: string, facilityType: string, tonnageSentOn: number}>} finalDestinations
- * @returns {Array<Array<{text: string}>>}
+ * @param {Array<{recipientName: string | null, facilityType: string | null, tonnageSentOn: number}>} finalDestinations
+ * @returns {Array<Array<{text: string | null}>>}
  */
 export function buildDestinationRows(finalDestinations) {
   return finalDestinations.map((finalDestination) => [
@@ -57,8 +57,8 @@ export function buildDestinationRows(finalDestinations) {
 
 /**
  * Build govukTable rows for destinations with address.
- * @param {Array<{recipientName: string, facilityType: string, address: string, tonnageSentOn: number}>} finalDestinations
- * @returns {Array<Array<{text: string}>>}
+ * @param {Array<{recipientName: string | null, facilityType: string | null, address: string | null, tonnageSentOn: number}>} finalDestinations
+ * @returns {Array<Array<{text: string | null}>>}
  */
 export function buildDestinationDetailRows(finalDestinations) {
   return finalDestinations.map((destination) => [

--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -7,10 +7,10 @@ import { buildValidationErrors } from './validation.js'
 
 /**
  * Builds view data by calling the guard function with a page-fields callback.
- * @param {(request: Request, buildPageFields: (ctx: object) => object, options: object) => Promise<object>} guardFn
+ * @param {(request: HapiRequest, buildPageFields: (ctx: object) => object, options: object) => Promise<object>} guardFn
  * @param {(ctx: object) => (localise: (key: string, params?: object) => string) => object} pageFields
  * @param {object} guardOptions
- * @param {Request} request
+ * @param {HapiRequest} request
  * @param {object} [options]
  * @returns {Promise<object>}
  */
@@ -42,12 +42,12 @@ function buildViewData(guardFn, pageFields, guardOptions, request, options) {
  * @param {string} config.fieldName - Payload field name
  * @param {import('joi').Schema} config.payloadSchema - Joi schema for POST payload
  * @param {(ctx: object) => (localise: (key: string, params?: object) => string) => object} config.pageFields - Returns localised page fields from context
- * @param {(request: Request, buildPageFields: (ctx: object) => object, options: object) => Promise<object>} config.guardFn - Guard function (buildExporterViewData or buildReprocessorViewData)
+ * @param {(request: HapiRequest, buildPageFields: (ctx: object) => object, options: object) => Promise<object>} config.guardFn - Guard function (buildExporterViewData or buildReprocessorViewData)
  * @param {object} [config.guardOptions] - Extra options passed to guardFn (e.g. { accreditedOnly: true })
  * @param {string} [config.nextPage] - Redirect target after saving
  * @param {string} [config.exceedsTotalErrorKey] - i18n key for the exceeds-total error (enables tonnage validation)
- * @param {(deps: { getViewData: (request: Request, options?: object) => Promise<object>, viewPath: string }) => (request: Request, h: ResponseToolkit) => Promise<ResponseObject>} [config.createPostHandler] - Factory for custom POST handler
- * @returns {{ getController: Partial<ServerRoute>, postController: Partial<ServerRoute> }}
+ * @param {(deps: { getViewData: (request: HapiRequest, options?: object) => Promise<object>, viewPath: string }) => (request: HapiRequest & { params: PeriodParams, payload: DataPagePayload }, h: ResponseToolkit) => Promise<ResponseObject>} [config.createPostHandler] - Factory for custom POST handler
+ * @returns {{ getController: DataPageController, postController: DataPagePostController }}
  */
 export function createDataPageControllers({
   viewPath,
@@ -60,7 +60,10 @@ export function createDataPageControllers({
   exceedsTotalErrorKey,
   createPostHandler
 }) {
-  /** @param {Request} request */
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {object} [options]
+   */
   const getViewData = (request, options = {}) =>
     buildViewData(guardFn, pageFields, guardOptions, request, options)
 
@@ -71,6 +74,10 @@ export function createDataPageControllers({
         params: periodParamsSchema
       }
     },
+    /**
+     * @param {HapiRequest & { params: PeriodParams }} request
+     * @param {ResponseToolkit} h
+     */
     async handler(request, h) {
       const viewData = await getViewData(request)
       return h.view(viewPath, viewData)
@@ -83,13 +90,16 @@ export function createDataPageControllers({
   } else if (exceedsTotalErrorKey) {
     postHandler = createTonnagePostHandler(
       fieldName,
-      nextPage,
+      /** @type {string} */ (nextPage),
       exceedsTotalErrorKey,
       getViewData,
       viewPath
     )
   } else {
-    postHandler = createSimplePostHandler(fieldName, nextPage)
+    postHandler = createSimplePostHandler(
+      fieldName,
+      /** @type {string} */ (nextPage)
+    )
   }
 
   /** @satisfies {Partial<ServerRoute>} */
@@ -98,6 +108,12 @@ export function createDataPageControllers({
       validate: {
         params: periodParamsSchema,
         payload: payloadSchema,
+        /**
+         * @param {HapiRequest & { params: PeriodParams, payload: DataPagePayload }} request
+         * @param {ResponseToolkit} h
+         * @param {Error | undefined} error Hapi's failAction contract — with
+         *   payload validation configured this is always the Joi ValidationError.
+         */
         async failAction(request, h, error) {
           const viewData = await getViewData(request, {
             value: request.payload[fieldName]
@@ -105,7 +121,7 @@ export function createDataPageControllers({
 
           const { errors, errorSummary } = buildValidationErrors(
             request,
-            error,
+            /** @type {import('joi').ValidationError} */ (error),
             { noteTypePlural: viewData.noteTypePlural }
           )
 
@@ -124,7 +140,7 @@ export function createDataPageControllers({
 /**
  * @param {string} fieldName
  * @param {string} nextPage
- * @returns {(request: Request, h: ResponseToolkit) => Promise<ResponseObject>}
+ * @returns {(request: HapiRequest & { params: PeriodParams, payload: DataPagePayload }, h: ResponseToolkit) => Promise<ResponseObject>}
  */
 function createSimplePostHandler(fieldName, nextPage) {
   return async (request, h) => {
@@ -154,9 +170,9 @@ function createSimplePostHandler(fieldName, nextPage) {
  * @param {string} fieldName
  * @param {string} nextPage
  * @param {string} errorKey - i18n key for the exceeds-total error message
- * @param {(request: Request, options?: object) => Promise<object>} getViewData
+ * @param {(request: HapiRequest & { params: PeriodParams }, options?: object) => Promise<object>} getViewData
  * @param {string} viewPath
- * @returns {(request: Request, h: ResponseToolkit) => Promise<ResponseObject>}
+ * @returns {(request: HapiRequest & { params: PeriodParams, payload: DataPagePayload }, h: ResponseToolkit) => Promise<ResponseObject>}
  */
 function createTonnagePostHandler(
   fieldName,
@@ -168,7 +184,7 @@ function createTonnagePostHandler(
   return async (request, h) => {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
-    const fieldValue = request.payload[fieldName]
+    const fieldValue = /** @type {number} */ (request.payload[fieldName])
     const session = request.auth.credentials
 
     const reportDetail = await fetchReportDetail(
@@ -180,7 +196,11 @@ function createTonnagePostHandler(
       session.idToken
     )
 
-    if (fieldValue > reportDetail.prn.issuedTonnage) {
+    const prn = /** @type {NonNullable<typeof reportDetail.prn>} */ (
+      reportDetail.prn
+    )
+
+    if (fieldValue > prn.issuedTonnage) {
       const viewData = await getViewData(request, { value: fieldValue })
       const periodShort = formatPeriodShort(
         { year, period },
@@ -221,5 +241,37 @@ function createTonnagePostHandler(
 }
 
 /**
- * @import { Request, ResponseObject, ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * Payload shape shared by every page built via `createDataPageControllers`.
+ * The `fieldName` key is validated by the page-specific payloadSchema.
+ * @typedef {{
+ *   action: 'continue' | 'save',
+ *   crumb?: string,
+ *   [field: string]: unknown
+ * }} DataPagePayload
+ */
+
+/**
+ * @typedef {{
+ *   options: { validate: { params: import('joi').Schema } },
+ *   handler: (request: HapiRequest & { params: PeriodParams }, h: ResponseToolkit) => Promise<ResponseObject>
+ * }} DataPageController
+ */
+
+/**
+ * @typedef {{
+ *   options: {
+ *     validate: {
+ *       params: import('joi').Schema,
+ *       payload: import('joi').Schema,
+ *       failAction: (request: HapiRequest & { params: PeriodParams, payload: DataPagePayload }, h: ResponseToolkit, error: Error | undefined) => Promise<ResponseObject>
+ *     }
+ *   },
+ *   handler: (request: HapiRequest & { params: PeriodParams, payload: DataPagePayload }, h: ResponseToolkit) => Promise<ResponseObject>
+ * }} DataPagePostController
+ */
+
+/**
+ * @import { ResponseObject, ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './period-params-schema.js'
  */

--- a/src/server/reports/helpers/derive-submission-status.js
+++ b/src/server/reports/helpers/derive-submission-status.js
@@ -3,7 +3,7 @@ import { SUBMISSION_STATUS } from '../constants.js'
 /**
  * Derive the submission status for a reporting period.
  * @param {string} endDate - ISO date string for the period end (e.g. "2026-01-31")
- * @param {{ id: string, status: string } | null} report - persisted report, or null
+ * @param {{ id: string, status: import('../constants.js').SubmissionStatusValue } | null} report - persisted report, or null
  * @returns {import('../constants.js').SubmissionStatusValue | null}
  */
 export function deriveSubmissionStatus(endDate, report) {

--- a/src/server/reports/helpers/fetch-report-detail.js
+++ b/src/server/reports/helpers/fetch-report-detail.js
@@ -39,9 +39,9 @@ export async function fetchReportDetail(
 
 /**
  * @typedef {{
- *   recipientName: string,
- *   facilityType: string,
- *   address: string,
+ *   recipientName: string | null,
+ *   facilityType: string | null,
+ *   address: string | null,
  *   tonnageSentOn: number
  * }} FinalDestinationEntry
  */
@@ -89,9 +89,9 @@ export async function fetchReportDetail(
  *   supportingInformation?: string,
  *   prn?: {
  *     issuedTonnage: number,
- *     freeTonnage: number,
- *     totalRevenue: number,
- *     averagePricePerTonne: number
+ *     freeTonnage: number | null,
+ *     totalRevenue: number | null,
+ *     averagePricePerTonne: number | null
  *   },
  *   recyclingActivity: {
  *     suppliers: SupplierEntry[],

--- a/src/server/reports/helpers/fetch-report-detail.js
+++ b/src/server/reports/helpers/fetch-report-detail.js
@@ -41,6 +41,7 @@ export async function fetchReportDetail(
  * @typedef {{
  *   recipientName: string,
  *   facilityType: string,
+ *   address: string,
  *   tonnageSentOn: number
  * }} FinalDestinationEntry
  */
@@ -86,6 +87,12 @@ export async function fetchReportDetail(
  *     submitted?: { at: string, by: { id: string, name: string, position: string } }
  *   },
  *   supportingInformation?: string,
+ *   prn?: {
+ *     issuedTonnage: number,
+ *     freeTonnage: number,
+ *     totalRevenue: number,
+ *     averagePricePerTonne: number
+ *   },
  *   recyclingActivity: {
  *     suppliers: SupplierEntry[],
  *     totalTonnageReceived: number,

--- a/src/server/reports/helpers/fetch-reporting-periods.js
+++ b/src/server/reports/helpers/fetch-reporting-periods.js
@@ -27,7 +27,7 @@ export async function fetchReportingPeriods(
  *   startDate: string,
  *   endDate: string,
  *   dueDate: string,
- *   report: { id: string, status: string } | null
+ *   report: { id: string, status: import('../constants.js').SubmissionStatusValue } | null
  * }} ReportingPeriod
  */
 

--- a/src/server/reports/helpers/redirect.js
+++ b/src/server/reports/helpers/redirect.js
@@ -1,7 +1,7 @@
 /**
  * Returns the redirect URL for save (reports list) or continue (next page).
- * @param {Request} request
- * @param {{ organisationId: string, registrationId: string, year: number, cadence: string, period: number }} params
+ * @param {HapiRequest} request
+ * @param {{ organisationId: string, registrationId: string, year: number, cadence: CadenceValue, period: number }} params
  * @param {string} action - 'continue' or 'save'
  * @param {string} nextPage - path segment for the continue destination (e.g. 'free-perns')
  * @returns {string}
@@ -20,5 +20,6 @@ export function getRedirectUrl(request, params, action, nextPage) {
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { CadenceValue } from '../constants.js'
  */

--- a/src/server/reports/helpers/validation.js
+++ b/src/server/reports/helpers/validation.js
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js'
+import { Decimal } from 'decimal.js'
 import Joi from 'joi'
 
 const TWO_DECIMAL_PLACES = 2
@@ -152,12 +152,13 @@ export const freeTonnagePayloadSchema = Joi.object({
 /**
  * Builds validation error objects from Joi error details, suitable for
  * govukErrorSummary and inline error display.
- * @param {Request} request
+ * @param {HapiRequest} request
  * @param {import('joi').ValidationError} error
  * @param {Record<string, unknown>} [interpolation] - Placeholder values for i18n message keys
  * @returns {{ errors: Record<string, { text: string }>, errorSummary: { titleText: string, errorList: Array<{ text: string, href: string }> } }}
  */
 export function buildValidationErrors(request, error, interpolation = {}) {
+  /** @type {Record<string, { text: string }>} */
   const errors = {}
   const errorList = []
 
@@ -178,5 +179,5 @@ export function buildValidationErrors(request, error, interpolation = {}) {
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/reports/helpers/versioned-payload-schema.js
+++ b/src/server/reports/helpers/versioned-payload-schema.js
@@ -1,5 +1,10 @@
 import Joi from 'joi'
 
+/**
+ * Shape produced by `versionedPayloadSchema` after Joi validation.
+ * @typedef {{ version: number, crumb?: string }} VersionedPayload
+ */
+
 export const versionedPayloadSchema = Joi.object({
   version: Joi.number().integer().min(1).required(),
   crumb: Joi.string()

--- a/src/server/reports/prn-summary-dispatcher.js
+++ b/src/server/reports/prn-summary-dispatcher.js
@@ -11,7 +11,7 @@ import {
 } from './reprocessor/prn-summary-controller.js'
 
 /**
- * @param {Request} request
+ * @param {HapiRequest & { params: PeriodParams }} request
  * @returns {Promise<boolean>}
  */
 async function isReprocessor(request) {
@@ -36,6 +36,10 @@ export const prnSummaryDispatchGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const reprocessor = await isReprocessor(request)
     const controller = reprocessor
@@ -58,6 +62,10 @@ export const prnSummaryDispatchPostController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams, payload: DataPagePayload }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const reprocessor = await isReprocessor(request)
     const controller = reprocessor
@@ -87,5 +95,8 @@ export const prnSummaryDispatchPostController = {
 }
 
 /**
- * @import { Request, ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
+ * @import { DataPagePayload } from './helpers/create-data-page-controllers.js'
  */

--- a/src/server/reports/prn-summary-dispatcher.test.js
+++ b/src/server/reports/prn-summary-dispatcher.test.js
@@ -44,7 +44,7 @@ const reprocessorRegistration = {
 const reportDetail = {
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   prn: {
     issuedTonnage: 91,
     totalRevenue: null,

--- a/src/server/reports/reprocessor/free-prns-controller.test.js
+++ b/src/server/reports/reprocessor/free-prns-controller.test.js
@@ -59,7 +59,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 200,
@@ -240,7 +240,7 @@ describe('#reprocessorFreePrnsController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/reprocessor/prn-summary-controller.test.js
+++ b/src/server/reports/reprocessor/prn-summary-controller.test.js
@@ -59,7 +59,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 200,
@@ -195,7 +195,7 @@ describe('#reprocessorPrnSummaryController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/reprocessor/reprocessor-page-guards.js
+++ b/src/server/reports/reprocessor/reprocessor-page-guards.js
@@ -14,8 +14,8 @@ import {
  * Fetches registration/accreditation and report detail, then enforces the
  * reprocessor guard (any cadence). Returns validated data for pages available
  * to all reprocessors (tonnes-recycled, tonnes-not-recycled).
- * @param {Request} request
- * @returns {Promise<{ registration: object, accreditation: object | undefined, reportDetail: object }>}
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @returns {Promise<{ registration: object, accreditation: object | undefined, reportDetail: ReportDetailResponse }>}
  */
 export async function fetchGuardedReprocessorData(request) {
   const { organisationId, registrationId, year, cadence, period } =
@@ -54,8 +54,8 @@ export async function fetchGuardedReprocessorData(request) {
  * Fetches registration/accreditation and report detail, then enforces the
  * accredited-reprocessor-monthly guard. Returns validated data for pages
  * available only to accredited reprocessors (prn-summary, free-prns).
- * @param {Request} request
- * @returns {Promise<{ registration: object, accreditation: object, reportDetail: object }>}
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @returns {Promise<{ registration: object, accreditation: object, reportDetail: ReportDetailResponse }>}
  */
 export async function fetchGuardedAccreditedReprocessorData(request) {
   const { registration, accreditation, reportDetail } =
@@ -78,8 +78,17 @@ export async function fetchGuardedAccreditedReprocessorData(request) {
  * Fetches guarded reprocessor data and builds the common view data fields
  * shared by reprocessor pages. Page-specific fields are merged from the
  * callback return value.
- * @param {Request} request
- * @param {(ctx: { registration: object, accreditation: object | undefined, reportDetail: object, material: string, periodLabel: string, periodPath: string, reportsListPath: string }) => object} buildPageFields
+ * @param {HapiRequest & { params: PeriodParams }} request
+ * @param {(ctx: {
+ *   registration: object,
+ *   accreditation: object | undefined,
+ *   reportDetail: ReportDetailResponse,
+ *   material: string,
+ *   periodLabel: string,
+ *   periodShort: string,
+ *   periodPath: string,
+ *   reportsListPath: string
+ * }) => { backUrl?: string, defaultValue?: unknown, [key: string]: unknown }} buildPageFields
  * @param {object} [options]
  * @param {unknown} [options.value]
  * @param {object} [options.errors]
@@ -127,5 +136,7 @@ export async function buildReprocessorViewData(
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from '../helpers/period-params-schema.js'
+ * @import { ReportDetailResponse } from '../helpers/fetch-report-detail.js'
  */

--- a/src/server/reports/reprocessor/reprocessor-page-guards.js
+++ b/src/server/reports/reprocessor/reprocessor-page-guards.js
@@ -42,8 +42,10 @@ export async function fetchGuardedReprocessorData(request) {
     throw Boom.notFound()
   }
 
-  const status = reportDetail.status?.currentStatus ?? reportDetail.status
-  if (!reportDetail.id || status !== 'in_progress') {
+  if (
+    !reportDetail.id ||
+    reportDetail.status?.currentStatus !== 'in_progress'
+  ) {
     throw Boom.notFound()
   }
 

--- a/src/server/reports/reprocessor/reprocessor-page-guards.test.js
+++ b/src/server/reports/reprocessor/reprocessor-page-guards.test.js
@@ -34,7 +34,7 @@ const accreditation = {
 const reportDetail = {
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   cadence: 'monthly',
   year: 2026,
   period: 1,
@@ -133,7 +133,7 @@ describe('#fetchGuardedReprocessorData', () => {
     })
     vi.mocked(fetchReportDetail).mockResolvedValue({
       ...reportDetail,
-      status: 'ready_to_submit'
+      status: { currentStatus: 'ready_to_submit' }
     })
 
     await expect(fetchGuardedReprocessorData(mockRequest)).rejects.toThrow(

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
@@ -59,7 +59,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 200,
@@ -162,7 +162,7 @@ describe('#tonnesNotRecycledController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
@@ -67,7 +67,7 @@ const reportDetail = {
   details: { material: 'plastic' },
   id: 'report-001',
   version: 1,
-  status: 'in_progress',
+  status: { currentStatus: 'in_progress' },
   supportingInformation: null,
   recyclingActivity: {
     totalTonnageReceived: 200,
@@ -191,7 +191,7 @@ describe('#tonnesRecycledController', () => {
       }) => {
         vi.mocked(fetchReportDetail).mockResolvedValue({
           ...reportDetail,
-          status: 'ready_to_submit'
+          status: { currentStatus: 'ready_to_submit' }
         })
 
         const { statusCode } = await server.inject({

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -85,7 +85,7 @@ function buildWasteExported(exportActivity, isExporter, isAccreditedExporter) {
 
 /**
  * @typedef {{
- *   destinationDetailRows: Array<Array<{text: string}>>,
+ *   destinationDetailRows: Array<Array<{text: string | null}>>,
  *   toExporters: string,
  *   toOtherSites: string,
  *   toReprocessors: string,

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -23,7 +23,14 @@ import { periodParamsSchema } from './helpers/period-params-schema.js'
 import { updateReportStatus } from './helpers/update-report-status.js'
 import { versionedPayloadSchema } from './helpers/versioned-payload-schema.js'
 
-/** @import { ReportDetailResponse } from './helpers/fetch-report-detail.js' */
+/**
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { CadenceValue } from './constants.js'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
+ * @import { ReportDetailResponse } from './helpers/fetch-report-detail.js'
+ * @import { VersionedPayload } from './helpers/versioned-payload-schema.js'
+ */
 
 /**
  * @param {{ at: string, by: { name: string } }} statusCreated
@@ -109,6 +116,10 @@ export const submitGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -131,10 +142,15 @@ export const submitGetController = {
       )
     ])
 
+    const status = /** @type {NonNullable<ReportDetailResponse['status']>} */ (
+      reportDetail.status
+    )
+
     const viewData = buildViewData({
       registration,
       accreditation,
       reportDetail,
+      status,
       organisationId,
       registrationId,
       year,
@@ -179,7 +195,7 @@ function buildPageLabels({
 
 /**
  * @param {ReportDetailResponse['recyclingActivity']} recyclingActivity
- * @returns {{ totalTonnage: string, supplierDetailRows: Array<Array<{text: string}>> }}
+ * @returns {{ totalTonnage: string, supplierDetailRows: Array<Array<{text: string | null}>> }}
  */
 const buildWasteReceivedViewData = (recyclingActivity) => ({
   totalTonnage: formatTonnage(recyclingActivity.totalTonnageReceived),
@@ -196,13 +212,26 @@ const buildRecyclingActivityViewData = (recyclingActivity) => ({
 })
 
 /**
- * @param {{ registration: object, accreditation: object | undefined, reportDetail: ReportDetailResponse, organisationId: string, registrationId: string, year: number, cadence: string, period: number, localise: (key: string, params?: Record<string, string>) => string, localiseUrl: (url: string) => string }} params
+ * @param {{
+ *   registration: object,
+ *   accreditation: object | undefined,
+ *   reportDetail: ReportDetailResponse,
+ *   status: NonNullable<ReportDetailResponse['status']>,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   year: number,
+ *   cadence: CadenceValue,
+ *   period: number,
+ *   localise: (key: string, params?: Record<string, string>) => string,
+ *   localiseUrl: (url: string) => string
+ * }} params
  * @returns {object}
  */
 function buildViewData({
   registration,
   accreditation,
   reportDetail,
+  status,
   organisationId,
   registrationId,
   year,
@@ -219,10 +248,7 @@ function buildViewData({
   const { noteTypePlural, wasteActionGerund } =
     getNoteTypeDisplayNames(registration)
 
-  const { createdBy, createdOn } = getCreationDetails(
-    reportDetail.status.created,
-    localise
-  )
+  const { createdBy, createdOn } = getCreationDetails(status.created, localise)
 
   const reportsUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
@@ -308,6 +334,13 @@ export const submitPostController = {
       payload: versionedPayloadSchema
     }
   },
+  /**
+   * @param {HapiRequest & {
+   *   params: PeriodParams,
+   *   payload: VersionedPayload
+   * }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -333,7 +366,3 @@ export const submitPostController = {
     )
   }
 }
-
-/**
- * @import { ServerRoute } from '@hapi/hapi'
- */

--- a/src/server/reports/supporting-information-controller.js
+++ b/src/server/reports/supporting-information-controller.js
@@ -24,6 +24,17 @@ const payloadSchema = Joi.object({
 })
 
 /**
+ * Supporting-information form payload after Joi validation. `failAction`
+ * runs before Joi coercion, so for failAction we narrow the pre-coerced
+ * shape to the subset we read back.
+ * @typedef {{
+ *   supportingInformation: string,
+ *   action: 'continue' | 'save',
+ *   crumb?: string
+ * }} SupportingInformationPayload
+ */
+
+/**
  * @param {string} basePath
  * @param {object} registration
  * @param {object | null} accreditation
@@ -44,7 +55,7 @@ function getBackPage(basePath, registration, accreditation) {
 }
 
 /**
- * @param {Request} request
+ * @param {HapiRequest & { params: PeriodParams }} request
  * @param {object} [options]
  * @param {string} [options.value] - Pre-fill value for textarea
  * @param {object} [options.errors] - Validation errors
@@ -106,6 +117,10 @@ export const supportingInformationGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const viewData = await buildViewData(request)
 
@@ -121,8 +136,17 @@ export const supportingInformationPostController = {
     validate: {
       params: periodParamsSchema,
       payload: payloadSchema,
+      /**
+       * @param {HapiRequest & { params: PeriodParams, payload: SupportingInformationPayload }} request
+       * @param {ResponseToolkit} h
+       * @param {Error | undefined} error Hapi's failAction contract — with
+       *   payload validation configured this is always the Joi ValidationError.
+       */
       async failAction(request, h, error) {
-        const { errors, errorSummary } = buildValidationErrors(request, error)
+        const { errors, errorSummary } = buildValidationErrors(
+          request,
+          /** @type {Joi.ValidationError} */ (error)
+        )
 
         const viewData = await buildViewData(request, {
           value: request.payload.supportingInformation,
@@ -134,6 +158,10 @@ export const supportingInformationPostController = {
       }
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams, payload: SupportingInformationPayload }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params
@@ -165,5 +193,7 @@ export const supportingInformationPostController = {
 }
 
 /**
- * @import { Request, ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
  */

--- a/src/server/reports/view-controller.js
+++ b/src/server/reports/view-controller.js
@@ -22,6 +22,12 @@ import { periodParamsSchema } from './helpers/period-params-schema.js'
 import { SUBMISSION_STATUS } from './constants.js'
 
 /**
+ * @import { ServerRoute, ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { PeriodParams } from './helpers/period-params-schema.js'
+ */
+
+/**
  * @param {{ localise: (key: string, params?: Record<string, string>) => string, periodLabel: string, noteTypePlural: string, wasteActionGerund: string, status: import('./constants.js').SubmissionStatusValue }} params
  * @returns {object}
  */
@@ -198,7 +204,7 @@ function buildWasteExported(exportActivity, isExporter, isAccredited) {
 }
 
 /**
- * @satisfies {Partial<import('@hapi/hapi').ServerRoute>}
+ * @satisfies {Partial<ServerRoute>}
  */
 export const viewGetController = {
   options: {
@@ -206,6 +212,10 @@ export const viewGetController = {
       params: periodParamsSchema
     }
   },
+  /**
+   * @param {HapiRequest & { params: PeriodParams }} request
+   * @param {ResponseToolkit} h
+   */
   async handler(request, h) {
     const { organisationId, registrationId, year, cadence, period } =
       request.params


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Drives the reports module to zero type errors (was 123; total repo count 265 → 142). A larger slice than earlier PRs because the whole subsystem shares the same guard helpers, period-params schema, and `ReportDetailResponse` typedef — splitting it would have thrashed those shared surfaces.

## What changed

- Annotated every handler and shared helper (`buildViewData`, `buildExporterViewData`, `buildReprocessorViewData`) with `HapiRequest & { params: PeriodParams, payload: ... }`.
- Introduced `VersionedPayload`, `SupportingInformationPayload`, `DataPagePayload` typedefs for the Joi-validated request bodies.
- Tightened `createDataPageControllers`' return type to `DataPageController` / `DataPagePostController` so `prn-summary-dispatcher` can invoke `handler` and `failAction` through concrete types.
- Narrowed `ReportingPeriod.report.status` to `SubmissionStatusValue` and added the missing `prn` / `address` fields to `ReportDetailResponse`, matching the backend's Joi schema (including `.allow(null)` nullability for `prn.{freeTonnage, totalRevenue, averagePricePerTonne}` and `FinalDestinationEntry.{recipientName, facilityType, address}`).
- Widened `buildSupplierDetailRows`, `buildOverseasSiteRows`, `buildDestinationDetailRows` etc. to `{ text: string | null }` to reflect the actual data shape the Govuk templates already tolerate.
- Dropped the `status?.currentStatus ?? reportDetail.status` fallback in the exporter/reprocessor page guards. The fallback existed to accommodate raw-string `status` fixtures in tests; every affected test fixture now uses the object form the backend actually returns.
- Cast `failAction`'s `error` to `Joi.ValidationError` per Hapi's contract.
- Switched `decimal.js` to the named `Decimal` export so lint picks up its constructable class declaration.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ