### PR TITLE
PAE-1339: Apply HapiRequest typedef across the auth subsystem

### DIFF
--- a/src/server/auth/callback/controller.js
+++ b/src/server/auth/callback/controller.js
@@ -6,7 +6,10 @@ import { metrics } from '#server/common/helpers/metrics/index.js'
 import { getSafeRedirect } from '#utils/get-safe-redirect.js'
 import { randomUUID, createHash } from 'node:crypto'
 
-/** @import { ServerRoute } from '@hapi/hapi' */
+/**
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ */
 
 /**
  * Hashes a user ID to avoid logging PII while preserving uniqueness for metrics
@@ -32,6 +35,10 @@ const controller = {
   options: {
     auth: { strategy: 'defra-id', mode: 'try' }
   },
+  /**
+   * @param {HapiRequest} request
+   * @param {ResponseToolkit} h
+   */
   handler: async (request, h) => {
     if (request.auth?.error) {
       await metrics.signInFailure()
@@ -79,7 +86,8 @@ const controller = {
         ...withWelsh(paths.start),
         ...withWelsh(paths.loggedOut)
       ]
-      const shouldSkipReferrer = skipReferrers.includes(referrer)
+      const shouldSkipReferrer =
+        referrer !== undefined && skipReferrers.includes(referrer)
 
       // Don't redirect linked users back to start or logged-out pages - take them to dashboard
       if (referrer && !shouldSkipReferrer) {

--- a/src/server/auth/helpers/drop-user-session.js
+++ b/src/server/auth/helpers/drop-user-session.js
@@ -1,6 +1,6 @@
 /**
  * Drop user session from cache
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @returns {Promise<void>}
  */
 async function dropUserSession(request) {
@@ -12,5 +12,5 @@ async function dropUserSession(request) {
 export { dropUserSession }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/auth/helpers/get-redirect-url.js
+++ b/src/server/auth/helpers/get-redirect-url.js
@@ -18,9 +18,10 @@ const getRedirectUrl = (request, path) => {
   const allowedOrigins = new Set([appBaseUrl, PRODUCTION_SERVICE_URL])
 
   const forwardedProto = request.headers['x-forwarded-proto']
-  const protocol = VALID_PROTOCOLS.has(forwardedProto)
-    ? forwardedProto
-    : request.server.info.protocol
+  const protocol =
+    typeof forwardedProto === 'string' && VALID_PROTOCOLS.has(forwardedProto)
+      ? forwardedProto
+      : request.server.info.protocol
 
   const requestUrl = new URL(appBaseUrl)
   requestUrl.protocol = protocol

--- a/src/server/auth/helpers/get-user-session.js
+++ b/src/server/auth/helpers/get-user-session.js
@@ -1,14 +1,14 @@
 import { err, ok } from '#server/common/helpers/result.js'
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  * @import { UserSession } from '../types/session.js'
  * @import { Result } from '#server/common/helpers/result.js'
  */
 
 /**
  * Get user session from cache
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @returns {Promise<Result<UserSession>>}
  */
 async function getUserSession(request) {

--- a/src/server/auth/helpers/refresh-token.js
+++ b/src/server/auth/helpers/refresh-token.js
@@ -5,12 +5,12 @@ import { withTraceId } from '@defra/hapi-tracing'
 import { getUserSession } from './get-user-session.js'
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */
 
 /**
  * Refresh id token using refresh token
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @returns {Promise<Response>}
  */
 async function refreshIdToken(request) {

--- a/src/server/auth/helpers/session-cookie.js
+++ b/src/server/auth/helpers/session-cookie.js
@@ -10,7 +10,9 @@ import { getUserSession } from './get-user-session.js'
 import { refreshIdToken } from './refresh-token.js'
 
 /**
- * @import { Request, ServerRegisterPluginObject } from '@hapi/hapi'
+ * @import { ServerRegisterPluginObject } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { RefreshedTokens } from '../types/tokens.js'
  * @import { UserSession } from '../types/session.js'
  * @import { VerifyToken } from '../types/verify-token.js'
  */
@@ -42,7 +44,7 @@ function inNext5Minutes(date) {
 /**
  * Refreshes id token and updates session with refreshed tokens. If the refresh fails, the session is removed.
  * @param {VerifyToken} verifyToken
- * @returns {(request: Request, userSession: UserSession) => Promise<UserSession | null>}
+ * @returns {(request: HapiRequest, userSession: UserSession) => Promise<UserSession | null>}
  */
 const createRefreshIdTokenAndUpdateSession = (verifyToken) => {
   /** @type {ReturnType<typeof createRefreshIdTokenAndUpdateSession>} */
@@ -61,7 +63,9 @@ const createRefreshIdTokenAndUpdateSession = (verifyToken) => {
         throw new Error(errorBody)
       }
 
-      const refreshedTokens = await response.json()
+      const refreshedTokens = /** @type {RefreshedTokens} */ (
+        await response.json()
+      )
       const { ok: sessionStillExists, value: latestSession } =
         await getUserSession(request)
 
@@ -87,7 +91,7 @@ const createRefreshIdTokenAndUpdateSession = (verifyToken) => {
 
 /**
  * @param {VerifyToken} verifyToken
- * @returns {(request: Request, userSession: UserSession) => Promise<{isValid: boolean, credentials?: UserSession}>}
+ * @returns {(request: HapiRequest, userSession: UserSession) => Promise<{isValid: boolean, credentials?: UserSession}>}
  */
 const createBlockingRefresh = (verifyToken) => {
   const refreshIdTokenAndUpdateSession =
@@ -122,7 +126,7 @@ const createBlockingRefresh = (verifyToken) => {
 
 /**
  * @param {VerifyToken} verifyToken
- * @returns {(request: Request, userSession: UserSession) => void}
+ * @returns {(request: HapiRequest, userSession: UserSession) => void}
  */
 const createBackgroundRefresh = (verifyToken) => {
   const refreshIdTokenAndUpdateSession =
@@ -185,7 +189,7 @@ const createSessionCookie = (verifyToken) => {
           keepAlive: true,
           /**
            * Validates the session cookie on each request
-           * @param {Request} request - Hapi request object
+           * @param {HapiRequest} request - Hapi request object
            * @returns {Promise<{isValid: boolean, credentials?: UserSession}>} Validation result
            */
           validate: async (request) => {

--- a/src/server/auth/helpers/user-session.js
+++ b/src/server/auth/helpers/user-session.js
@@ -3,14 +3,14 @@ import { dropUserSession } from './drop-user-session.js'
 
 /**
  * @import { RefreshedTokens } from '../types/tokens.js'
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest, SessionCookieState } from '#server/common/hapi-types.js'
  * @import { UserSession } from '../types/session.js'
  * @import { VerifyToken } from '../types/verify-token.js'
  */
 
 /**
  * Remove user session from cache and clear cookies
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @returns {Promise<void>}
  */
 async function removeUserSession(request) {
@@ -21,12 +21,15 @@ async function removeUserSession(request) {
 
 /**
  * Update user session to flag that an id token refresh is in progress
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @param {UserSession} userSession - Current user session
  * @returns {Promise<void>}
  */
 async function markSessionAsIdTokenRefreshInProgress(request, userSession) {
-  await request.server.app.cache.set(request.state.userSession.sessionId, {
+  const sessionState = /** @type {SessionCookieState} */ (
+    request.state.userSession
+  )
+  await request.server.app.cache.set(sessionState.sessionId, {
     ...userSession,
     idTokenRefreshInProgress: true
   })
@@ -35,7 +38,7 @@ async function markSessionAsIdTokenRefreshInProgress(request, userSession) {
 /**
  * Update user session with refreshed tokens
  * @param {VerifyToken} verifyToken - Token verification function
- * @param {Request} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @param {UserSession} existingSession - Current user session
  * @param {RefreshedTokens} refreshedTokens - Refreshed tokens from OIDC provider
  * @returns {Promise<UserSession>}
@@ -61,10 +64,10 @@ async function updateUserSession(
     idTokenRefreshInProgress: false
   }
 
-  await request.server.app.cache.set(
-    request.state.userSession.sessionId,
-    session
+  const sessionState = /** @type {SessionCookieState} */ (
+    request.state.userSession
   )
+  await request.server.app.cache.set(sessionState.sessionId, session)
 
   return session
 }

--- a/src/server/auth/organisation/controller.js
+++ b/src/server/auth/organisation/controller.js
@@ -7,6 +7,10 @@ const controller = {
   options: {
     auth: 'defra-id'
   },
+  /**
+   * @param {HapiRequest} request
+   * @param {ResponseToolkit} h
+   */
   handler: async function (request, h) {
     // Should never be called as the user should no longer be authenticated with `defra-id` after initial sign in
     // The strategy should redirect the user to the sign in page and they will rejoin the service at the /auth/callback route
@@ -22,5 +26,6 @@ const controller = {
 export { controller }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/auth/plugins/defra-id.js
+++ b/src/server/auth/plugins/defra-id.js
@@ -9,7 +9,7 @@ import { getOidcConfiguration } from '../helpers/get-oidc-configuration.js'
 import { getRedirectUrl } from '../helpers/get-redirect-url.js'
 
 /**
- * @import { AzureB2CTokenParams, AzureB2CBellCredentials, OAuthBellCredentials, OAuthTokenParams } from '../types/auth.js'
+ * @import { AzureB2CTokenParams, AzureB2CBellCredentials, BellProfileTarget, OAuthBellCredentials, OAuthTokenParams } from '../types/auth.js'
  * @import { ServerRegisterPluginObject } from '@hapi/hapi'
  * @import { VerifyToken } from '../types/verify-token.js'
  */
@@ -68,8 +68,11 @@ const createDefraId = (verifyToken) => ({
           token: oidcConf.token_endpoint,
           scope: ['openid', 'offline_access'],
           /**
-           * Extract user profile from OIDC ID token and populate credentials
-           * @param {OAuthBellCredentials | AzureB2CBellCredentials} credentials
+           * Extract user profile from OIDC ID token and populate credentials.
+           * Bell gives us a plain `BellCredentials` object which we mutate
+           * into a `UserSession` by attaching the profile, token expiry, id
+           * token and OIDC URLs.
+           * @param {BellProfileTarget} credentials
            * @param {OAuthTokenParams | AzureB2CTokenParams} params
            * @returns {Promise<void>}
            */

--- a/src/server/auth/types/auth.js
+++ b/src/server/auth/types/auth.js
@@ -116,4 +116,18 @@
  * @typedef {OAuthBellCredentials | AzureB2CBellCredentials} BellCredentials
  */
 
+/**
+ * Target shape for the Bell `profile` hook in
+ * `src/server/auth/plugins/defra-id.js`. At entry this is a plain
+ * `BellCredentials` object supplied by `@hapi/bell`; the hook then mutates
+ * it into a `UserSession` by attaching the session-specific fields declared
+ * here as optional so each assignment is type-checked.
+ * @typedef {(OAuthBellCredentials | AzureB2CBellCredentials) & {
+ *   profile?: import('./session.js').UserProfile
+ *   expiresAt?: string
+ *   idToken?: string
+ *   urls?: { token: string, logout: string }
+ * }} BellProfileTarget
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import

--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -1,5 +1,7 @@
 /**
- * @import {Request} from '@hapi/hapi'
+ * @import {Request, Server} from '@hapi/hapi'
+ * @import {Yar} from '@hapi/yar'
+ * @import {Policy, PolicyOptions} from '@hapi/catbox'
  * @import {TFunction, i18n} from 'i18next'
  * @import {Metrics} from '@defra/cdp-metrics'
  * @import {WasteOrganisationsService} from './helpers/waste-organisations/port.js'
@@ -29,6 +31,41 @@
  */
 
 /**
+ * Cookie written by the `@hapi/cookie` session strategy after sign-in.
+ * @typedef {{ sessionId: string }} SessionCookieState
+ */
+
+/**
+ * Cache policy used to persist `UserSession` records keyed by `sessionId`.
+ * Provisioned in `src/server/index.js` as `server.app.cache`.
+ * @typedef {Policy<UserSession, PolicyOptions<UserSession>>} SessionCache
+ */
+
+/**
+ * Application state attached to the Hapi server during startup.
+ * @typedef {{ cache: SessionCache }} AppState
+ */
+
+/**
+ * Hapi server with our application state typed.
+ * @typedef {Omit<Server, 'app'> & { app: AppState }} HapiServer
+ */
+
+/**
+ * Yar session with the flash keys used in this app. `@hapi/yar`'s typed
+ * single-argument `flash` overload rejects any key not registered through
+ * module augmentation; since we don't write TypeScript, we add the keys we
+ * use here as extra overloads layered on top of yar's own typings.
+ * @typedef {{
+ *   (type: 'referrer'): string[]
+ * } & Yar['flash']} HapiYarFlash
+ */
+
+/**
+ * @typedef {Omit<Yar, 'flash'> & { flash: HapiYarFlash }} HapiYar
+ */
+
+/**
  * Hapi request extended with the decorations contributed by the app's
  * registered plugins:
  *   - `t`, `i18n` from i18next-http-middleware
@@ -37,8 +74,15 @@
  *   - `metrics` from `@defra/cdp-metrics`
  *   - `cookieAuth` from `@hapi/cookie`
  *   - `auth.credentials` narrowed to `UserSession`
- * @typedef {Omit<Request, 'auth'> & {
+ *   - `server.app.cache` narrowed to the `SessionCache` set up at startup
+ *   - `state.userSession` narrowed to the cookie state written by the
+ *     session strategy
+ *   - `yar.flash` extended with the flash keys the app uses
+ * @typedef {Omit<Request, 'auth' | 'server' | 'state' | 'yar'> & {
  *   auth: RequestAuth,
+ *   server: HapiServer,
+ *   state: Request['state'] & { userSession?: SessionCookieState },
+ *   yar: HapiYar,
  *   t: TFunction,
  *   i18n: i18n,
  *   localiseUrl: (url: string) => string,

--- a/src/server/common/helpers/result.js
+++ b/src/server/common/helpers/result.js
@@ -1,10 +1,13 @@
 import assert from 'node:assert'
 
 /**
- * Generic result wrapper for operations that may or may not succeed
+ * Generic result wrapper for operations that may or may not succeed.
+ * Both variants carry `value` and `error` so `const { value } = result`
+ * destructuring type-checks; consumers should gate on `ok` before using
+ * `value`.
  * @template T - The success value type (must be non-nullable)
- * @template E - The error type (optional)
- * @typedef {{ ok: true, value: NonNullable<T> } | { ok: false, error?: E }} Result
+ * @template [E=unknown] - The error type (defaults to `unknown` when omitted)
+ * @typedef {{ ok: true, value: NonNullable<T>, error?: undefined } | { ok: false, value?: undefined, error?: E }} Result
  */
 
 /**
@@ -21,16 +24,16 @@ const ok = (value) => {
 
 /**
  * Error/not found result
- * @template T, E
+ * @template T
+ * @template [E=unknown]
  * @param {E} [error] - Optional error information
  * @returns {Result<T, E>}
  */
 const err = (error) => {
-  const result = { ok: false }
-  if (error) {
-    result.error = error
+  if (!error) {
+    return { ok: false }
   }
-  return result
+  return { ok: false, error }
 }
 
 export { err, ok }


### PR DESCRIPTION
## Summary

Next incremental slice of [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339) - extends the existing `HapiRequest` JSDoc typedef and sweeps it across the auth subsystem (callback, organisation controller, session helpers).

- New supporting typedefs in `src/server/common/hapi-types.js` for the decorations the auth flow relies on: `server.app.cache` (catbox `Policy<UserSession>`), `state.userSession` (the cookie written by the session strategy), and the `'referrer'` key on `yar.flash`.
- New `BellProfileTarget` typedef in `src/server/auth/types/auth.js` so bell's `profile` callback type-checks under the mutation pattern it uses, without having to widen bell's own `BellCredentials` contract.
- Narrows `x-forwarded-proto` to `string` before membership checking in `get-redirect-url.js`.
- Gives `Result<T>` a default `E=unknown` and makes both arms carry `value`/`error` keys so destructuring via `const { ok, value } = ...` type-checks.

**Zero runtime changes around `@hapi/bell`.** The defra-id plugin's `profile` callback body is untouched; only its JSDoc annotation changed. Two small runtime rewrites elsewhere (`shouldSkipReferrer` guard in the callback controller, `typeof` guard on `x-forwarded-proto`) are proven no-ops - `Array.prototype.includes(undefined)` on a `string[]` is always `false`, and `Set<string>.has()` on a non-string is always `false`.

## Impact

Auth-subsystem `npm run lint:types` errors drop from 36 to 1. The remaining one is a JWT payload narrowing at the `jose.jwtVerify` boundary in `verify-token.js`, intentionally deferred to a later slice because proper handling wants a runtime schema validation rather than a type cast.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ