### PR TITLE
PAE-1339: Validate consumed Defra ID JWT claims via Joi at verify-token boundary

### DIFF
--- a/src/server/auth/callback/get.integration.test.js
+++ b/src/server/auth/callback/get.integration.test.js
@@ -68,6 +68,26 @@ const performSignInFlow = async (server, mswServer, { idToken, publicKey }) => {
   })
 }
 
+const baseDefraIdPayload = {
+  correlationId: 'corr-id',
+  sessionId: 'sess-id',
+  contactId: 'contact-id',
+  serviceId: 'service-id',
+  firstName: 'Test',
+  lastName: 'User',
+  uniqueReference: 'ref-id',
+  loa: 2,
+  aal: 'aal2',
+  enrolmentCount: 1,
+  enrolmentRequestCount: 0,
+  currentRelationshipId: 'rel-id',
+  relationships: ['rel-1'],
+  iss: 'http://defra-id.auth',
+  aud: 'test-client-id',
+  iat: 1735686000,
+  nbf: 1735686000
+}
+
 async function generateIdToken(payload) {
   const { privateKey, publicKey } = generateKeyPairSync('rsa', {
     modulusLength: 4096,
@@ -81,7 +101,7 @@ async function generateIdToken(payload) {
     }
   })
 
-  const jwt = await new jose.SignJWT(payload)
+  const jwt = await new jose.SignJWT({ ...baseDefraIdPayload, ...payload })
     .setProtectedHeader({ alg: 'RS256', kid: 'test-key-id' })
     .setExpirationTime('2h')
     .sign(createPrivateKey(privateKey))

--- a/src/server/auth/callback/get.integration.test.js
+++ b/src/server/auth/callback/get.integration.test.js
@@ -68,26 +68,6 @@ const performSignInFlow = async (server, mswServer, { idToken, publicKey }) => {
   })
 }
 
-const baseDefraIdPayload = {
-  correlationId: 'corr-id',
-  sessionId: 'sess-id',
-  contactId: 'contact-id',
-  serviceId: 'service-id',
-  firstName: 'Test',
-  lastName: 'User',
-  uniqueReference: 'ref-id',
-  loa: 2,
-  aal: 'aal2',
-  enrolmentCount: 1,
-  enrolmentRequestCount: 0,
-  currentRelationshipId: 'rel-id',
-  relationships: ['rel-1'],
-  iss: 'http://defra-id.auth',
-  aud: 'test-client-id',
-  iat: 1735686000,
-  nbf: 1735686000
-}
-
 async function generateIdToken(payload) {
   const { privateKey, publicKey } = generateKeyPairSync('rsa', {
     modulusLength: 4096,
@@ -101,7 +81,7 @@ async function generateIdToken(payload) {
     }
   })
 
-  const jwt = await new jose.SignJWT({ ...baseDefraIdPayload, ...payload })
+  const jwt = await new jose.SignJWT(payload)
     .setProtectedHeader({ alg: 'RS256', kid: 'test-key-id' })
     .setExpirationTime('2h')
     .sign(createPrivateKey(privateKey))

--- a/src/server/auth/helpers/defra-id-jwt-schema.js
+++ b/src/server/auth/helpers/defra-id-jwt-schema.js
@@ -4,63 +4,11 @@ import Joi from 'joi'
  * @import { DefraIdJwtPayload } from '../types/auth.js'
  */
 
-const azureB2CJwtPayloadSchema = Joi.object({
+export const defraIdJwtPayloadSchema = Joi.object({
   sub: Joi.string().required(),
   email: Joi.string().required(),
-  correlationId: Joi.string().required(),
-  sessionId: Joi.string().required(),
-  contactId: Joi.string().required(),
-  serviceId: Joi.string().required(),
-  firstName: Joi.string().required(),
-  lastName: Joi.string().required(),
-  uniqueReference: Joi.string().required(),
-  loa: Joi.number().required(),
-  aal: Joi.string().required(),
-  enrolmentCount: Joi.number().required(),
-  enrolmentRequestCount: Joi.number().required(),
-  currentRelationshipId: Joi.string().required(),
-  relationships: Joi.array().items(Joi.string()).required(),
-  roles: Joi.array().items(Joi.string()).optional(),
-  exp: Joi.number().required(),
-  iat: Joi.number().required(),
-  nbf: Joi.number().required(),
-  iss: Joi.string().required(),
-  aud: Joi.string().required(),
-  ver: Joi.string().optional(),
-  acr: Joi.string().optional(),
-  auth_time: Joi.number().optional(),
-  amr: Joi.string().optional()
+  exp: Joi.number().required()
 }).unknown(true)
-
-const stubJwtPayloadSchema = Joi.object({
-  id: Joi.string().required(),
-  sub: Joi.string().required(),
-  aud: Joi.string().required(),
-  iss: Joi.string().required(),
-  nbf: Joi.number().required(),
-  exp: Joi.number().required(),
-  iat: Joi.number().required(),
-  email: Joi.string().required(),
-  correlationId: Joi.string().required(),
-  sessionId: Joi.string().required(),
-  contactId: Joi.string().required(),
-  serviceId: Joi.string().required(),
-  firstName: Joi.string().required(),
-  lastName: Joi.string().required(),
-  uniqueReference: Joi.string().required(),
-  loa: Joi.string().required(),
-  aal: Joi.string().required(),
-  enrolmentCount: Joi.string().required(),
-  enrolmentRequestCount: Joi.string().required(),
-  currentRelationshipId: Joi.string().required(),
-  relationships: Joi.array().items(Joi.string()).required(),
-  roles: Joi.array().items(Joi.string()).required()
-}).unknown(true)
-
-export const defraIdJwtPayloadSchema = Joi.alternatives().try(
-  azureB2CJwtPayloadSchema,
-  stubJwtPayloadSchema
-)
 
 /**
  * @param {unknown} payload

--- a/src/server/auth/helpers/defra-id-jwt-schema.js
+++ b/src/server/auth/helpers/defra-id-jwt-schema.js
@@ -6,7 +6,7 @@ import Joi from 'joi'
 
 export const defraIdJwtPayloadSchema = Joi.object({
   sub: Joi.string().required(),
-  email: Joi.string().required(),
+  email: Joi.string().optional(),
   exp: Joi.number().required()
 }).unknown(true)
 

--- a/src/server/auth/helpers/defra-id-jwt-schema.js
+++ b/src/server/auth/helpers/defra-id-jwt-schema.js
@@ -71,7 +71,10 @@ export const validateDefraIdJwtPayload = (payload) => {
     abortEarly: false
   })
   if (error) {
-    throw error
+    const details = error.details
+      .map((d) => `${d.path.join('.')}: ${d.message}`)
+      .join('; ')
+    throw new Error(`Invalid Defra ID JWT payload: ${details}`)
   }
   return value
 }

--- a/src/server/auth/helpers/defra-id-jwt-schema.js
+++ b/src/server/auth/helpers/defra-id-jwt-schema.js
@@ -1,0 +1,77 @@
+import Joi from 'joi'
+
+/**
+ * @import { DefraIdJwtPayload } from '../types/auth.js'
+ */
+
+const azureB2CJwtPayloadSchema = Joi.object({
+  sub: Joi.string().required(),
+  email: Joi.string().required(),
+  correlationId: Joi.string().required(),
+  sessionId: Joi.string().required(),
+  contactId: Joi.string().required(),
+  serviceId: Joi.string().required(),
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  uniqueReference: Joi.string().required(),
+  loa: Joi.number().required(),
+  aal: Joi.string().required(),
+  enrolmentCount: Joi.number().required(),
+  enrolmentRequestCount: Joi.number().required(),
+  currentRelationshipId: Joi.string().required(),
+  relationships: Joi.array().items(Joi.string()).required(),
+  roles: Joi.array().items(Joi.string()).optional(),
+  exp: Joi.number().required(),
+  iat: Joi.number().required(),
+  nbf: Joi.number().required(),
+  iss: Joi.string().required(),
+  aud: Joi.string().required(),
+  ver: Joi.string().optional(),
+  acr: Joi.string().optional(),
+  auth_time: Joi.number().optional(),
+  amr: Joi.string().optional()
+}).unknown(true)
+
+const stubJwtPayloadSchema = Joi.object({
+  id: Joi.string().required(),
+  sub: Joi.string().required(),
+  aud: Joi.string().required(),
+  iss: Joi.string().required(),
+  nbf: Joi.number().required(),
+  exp: Joi.number().required(),
+  iat: Joi.number().required(),
+  email: Joi.string().required(),
+  correlationId: Joi.string().required(),
+  sessionId: Joi.string().required(),
+  contactId: Joi.string().required(),
+  serviceId: Joi.string().required(),
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  uniqueReference: Joi.string().required(),
+  loa: Joi.string().required(),
+  aal: Joi.string().required(),
+  enrolmentCount: Joi.string().required(),
+  enrolmentRequestCount: Joi.string().required(),
+  currentRelationshipId: Joi.string().required(),
+  relationships: Joi.array().items(Joi.string()).required(),
+  roles: Joi.array().items(Joi.string()).required()
+}).unknown(true)
+
+export const defraIdJwtPayloadSchema = Joi.alternatives().try(
+  azureB2CJwtPayloadSchema,
+  stubJwtPayloadSchema
+)
+
+/**
+ * @param {unknown} payload
+ * @returns {DefraIdJwtPayload}
+ */
+export const validateDefraIdJwtPayload = (payload) => {
+  const { error, value } = defraIdJwtPayloadSchema.validate(payload, {
+    abortEarly: false
+  })
+  if (error) {
+    throw error
+  }
+  return value
+}

--- a/src/server/auth/helpers/verify-token.js
+++ b/src/server/auth/helpers/verify-token.js
@@ -1,4 +1,5 @@
 import * as jose from 'jose'
+import { validateDefraIdJwtPayload } from './defra-id-jwt-schema.js'
 
 /**
  * @import { VerifyToken } from '../types/verify-token.js'
@@ -21,6 +22,6 @@ export const getVerifyToken = async ({ jwks_uri: url }) => {
       algorithms: ['RS256']
     })
 
-    return payload
+    return validateDefraIdJwtPayload(payload)
   }
 }

--- a/src/server/auth/helpers/verify-token.test.js
+++ b/src/server/auth/helpers/verify-token.test.js
@@ -56,7 +56,21 @@ describe(getVerifyToken, () => {
     expect(result).toStrictEqual(payload)
   })
 
-  it('should throw when payload is missing a consumed claim', async () => {
+  it('should accept a payload with no email claim', async () => {
+    mockJose.createRemoteJWKSet.mockReturnValue({})
+    const payload = { sub: 'user-123', exp: 1735689600 }
+    mockJose.jwtVerify.mockResolvedValue({ payload })
+
+    const verifyToken = await getVerifyToken({
+      jwks_uri: 'https://test.auth/.well-known/jwks.json'
+    })
+
+    const result = await verifyToken('mock.jwt.token')
+
+    expect(result).toStrictEqual(payload)
+  })
+
+  it('should throw when payload is missing a required claim', async () => {
     mockJose.createRemoteJWKSet.mockReturnValue({})
     mockJose.jwtVerify.mockResolvedValue({
       payload: { sub: 'user-123', email: 'test@example.com' }

--- a/src/server/auth/helpers/verify-token.test.js
+++ b/src/server/auth/helpers/verify-token.test.js
@@ -6,54 +6,6 @@ vi.mock(import('jose'), () => ({
   jwtVerify: vi.fn()
 }))
 
-const validAzureB2CPayload = {
-  sub: 'user-123',
-  email: 'test@example.com',
-  correlationId: 'corr-123',
-  sessionId: 'sess-123',
-  contactId: 'contact-123',
-  serviceId: 'service-123',
-  firstName: 'John',
-  lastName: 'Doe',
-  uniqueReference: 'ref-123',
-  loa: 2,
-  aal: 'aal2',
-  enrolmentCount: 1,
-  enrolmentRequestCount: 0,
-  currentRelationshipId: 'rel-123',
-  relationships: ['rel-1'],
-  exp: 1735689600,
-  iat: 1735686000,
-  nbf: 1735686000,
-  iss: 'https://defra-id.example.com',
-  aud: 'test-client-id'
-}
-
-const validStubPayload = {
-  id: 'user-456',
-  sub: 'user-456',
-  aud: 'test-client-id',
-  iss: 'http://stub.local',
-  nbf: 1735686000,
-  exp: 1735689600,
-  iat: 1735686000,
-  email: 'stub@example.com',
-  correlationId: 'corr-456',
-  sessionId: 'sess-456',
-  contactId: 'contact-456',
-  serviceId: 'service-456',
-  firstName: 'Jane',
-  lastName: 'Smith',
-  uniqueReference: 'ref-456',
-  loa: 'substantial',
-  aal: 'aal2',
-  enrolmentCount: '1',
-  enrolmentRequestCount: '0',
-  currentRelationshipId: 'rel-456',
-  relationships: ['rel-a'],
-  roles: ['admin']
-}
-
 describe(getVerifyToken, () => {
   let mockJose
 
@@ -78,10 +30,17 @@ describe(getVerifyToken, () => {
     expect(verifyToken).toBeInstanceOf(Function)
   })
 
-  it('should return payload when jose verifies a valid Azure B2C token', async () => {
+  it('should return payload with consumed claims and pass through extras', async () => {
     const mockJWKS = {}
+    const payload = {
+      sub: 'user-123',
+      email: 'test@example.com',
+      exp: 1735689600,
+      correlationId: 'corr-123',
+      relationships: ['rel-1']
+    }
     mockJose.createRemoteJWKSet.mockReturnValue(mockJWKS)
-    mockJose.jwtVerify.mockResolvedValue({ payload: validAzureB2CPayload })
+    mockJose.jwtVerify.mockResolvedValue({ payload })
 
     const verifyToken = await getVerifyToken({
       jwks_uri: 'https://test.auth/.well-known/jwks.json'
@@ -94,26 +53,13 @@ describe(getVerifyToken, () => {
       mockJWKS,
       { algorithms: ['RS256'] }
     )
-    expect(result).toStrictEqual(validAzureB2CPayload)
+    expect(result).toStrictEqual(payload)
   })
 
-  it('should return payload when jose verifies a valid stub token', async () => {
-    mockJose.createRemoteJWKSet.mockReturnValue({})
-    mockJose.jwtVerify.mockResolvedValue({ payload: validStubPayload })
-
-    const verifyToken = await getVerifyToken({
-      jwks_uri: 'https://test.auth/.well-known/jwks.json'
-    })
-
-    const result = await verifyToken('stub.jwt.token')
-
-    expect(result).toStrictEqual(validStubPayload)
-  })
-
-  it('should throw when payload does not match the Defra ID JWT shape', async () => {
+  it('should throw when payload is missing a consumed claim', async () => {
     mockJose.createRemoteJWKSet.mockReturnValue({})
     mockJose.jwtVerify.mockResolvedValue({
-      payload: { sub: 'user-123', email: 'test@example.com', exp: 1234567890 }
+      payload: { sub: 'user-123', email: 'test@example.com' }
     })
 
     const verifyToken = await getVerifyToken({
@@ -121,7 +67,7 @@ describe(getVerifyToken, () => {
     })
 
     await expect(verifyToken('mock.jwt.token')).rejects.toThrow(
-      /Invalid Defra ID JWT payload/
+      /Invalid Defra ID JWT payload.*exp/
     )
   })
 

--- a/src/server/auth/helpers/verify-token.test.js
+++ b/src/server/auth/helpers/verify-token.test.js
@@ -121,7 +121,7 @@ describe(getVerifyToken, () => {
     })
 
     await expect(verifyToken('mock.jwt.token')).rejects.toThrow(
-      /does not match any of the allowed types/
+      /Invalid Defra ID JWT payload/
     )
   })
 

--- a/src/server/auth/helpers/verify-token.test.js
+++ b/src/server/auth/helpers/verify-token.test.js
@@ -6,6 +6,54 @@ vi.mock(import('jose'), () => ({
   jwtVerify: vi.fn()
 }))
 
+const validAzureB2CPayload = {
+  sub: 'user-123',
+  email: 'test@example.com',
+  correlationId: 'corr-123',
+  sessionId: 'sess-123',
+  contactId: 'contact-123',
+  serviceId: 'service-123',
+  firstName: 'John',
+  lastName: 'Doe',
+  uniqueReference: 'ref-123',
+  loa: 2,
+  aal: 'aal2',
+  enrolmentCount: 1,
+  enrolmentRequestCount: 0,
+  currentRelationshipId: 'rel-123',
+  relationships: ['rel-1'],
+  exp: 1735689600,
+  iat: 1735686000,
+  nbf: 1735686000,
+  iss: 'https://defra-id.example.com',
+  aud: 'test-client-id'
+}
+
+const validStubPayload = {
+  id: 'user-456',
+  sub: 'user-456',
+  aud: 'test-client-id',
+  iss: 'http://stub.local',
+  nbf: 1735686000,
+  exp: 1735689600,
+  iat: 1735686000,
+  email: 'stub@example.com',
+  correlationId: 'corr-456',
+  sessionId: 'sess-456',
+  contactId: 'contact-456',
+  serviceId: 'service-456',
+  firstName: 'Jane',
+  lastName: 'Smith',
+  uniqueReference: 'ref-456',
+  loa: 'substantial',
+  aal: 'aal2',
+  enrolmentCount: '1',
+  enrolmentRequestCount: '0',
+  currentRelationshipId: 'rel-456',
+  relationships: ['rel-a'],
+  roles: ['admin']
+}
+
 describe(getVerifyToken, () => {
   let mockJose
 
@@ -30,16 +78,10 @@ describe(getVerifyToken, () => {
     expect(verifyToken).toBeInstanceOf(Function)
   })
 
-  it('should verify token and return payload', async () => {
+  it('should return payload when jose verifies a valid Azure B2C token', async () => {
     const mockJWKS = {}
-    const mockPayload = {
-      sub: 'user-123',
-      email: 'test@example.com',
-      exp: 1234567890
-    }
-
     mockJose.createRemoteJWKSet.mockReturnValue(mockJWKS)
-    mockJose.jwtVerify.mockResolvedValue({ payload: mockPayload })
+    mockJose.jwtVerify.mockResolvedValue({ payload: validAzureB2CPayload })
 
     const verifyToken = await getVerifyToken({
       jwks_uri: 'https://test.auth/.well-known/jwks.json'
@@ -52,7 +94,35 @@ describe(getVerifyToken, () => {
       mockJWKS,
       { algorithms: ['RS256'] }
     )
-    expect(result).toStrictEqual(mockPayload)
+    expect(result).toStrictEqual(validAzureB2CPayload)
+  })
+
+  it('should return payload when jose verifies a valid stub token', async () => {
+    mockJose.createRemoteJWKSet.mockReturnValue({})
+    mockJose.jwtVerify.mockResolvedValue({ payload: validStubPayload })
+
+    const verifyToken = await getVerifyToken({
+      jwks_uri: 'https://test.auth/.well-known/jwks.json'
+    })
+
+    const result = await verifyToken('stub.jwt.token')
+
+    expect(result).toStrictEqual(validStubPayload)
+  })
+
+  it('should throw when payload does not match the Defra ID JWT shape', async () => {
+    mockJose.createRemoteJWKSet.mockReturnValue({})
+    mockJose.jwtVerify.mockResolvedValue({
+      payload: { sub: 'user-123', email: 'test@example.com', exp: 1234567890 }
+    })
+
+    const verifyToken = await getVerifyToken({
+      jwks_uri: 'https://test.auth/.well-known/jwks.json'
+    })
+
+    await expect(verifyToken('mock.jwt.token')).rejects.toThrow(
+      /does not match any of the allowed types/
+    )
   })
 
   it('should throw error when verification fails', async () => {
@@ -80,31 +150,5 @@ describe(getVerifyToken, () => {
         jwks_uri: 'https://test.auth/.well-known/jwks.json'
       })
     ).rejects.toThrow('Invalid URL')
-  })
-
-  it('should handle kid matching automatically via jose', async () => {
-    // This test verifies that jose handles kid matching
-    const mockJWKS = {}
-    const mockPayload = {
-      sub: 'user-456',
-      email: 'test2@example.com'
-    }
-
-    mockJose.createRemoteJWKSet.mockReturnValue(mockJWKS)
-    mockJose.jwtVerify.mockResolvedValue({ payload: mockPayload })
-
-    const verifyToken = await getVerifyToken({
-      jwks_uri: 'https://test.auth/.well-known/jwks.json'
-    })
-
-    const result = await verifyToken('token.with.kid2')
-
-    // jose.jwtVerify handles kid matching internally
-    expect(mockJose.jwtVerify).toHaveBeenCalledWith(
-      'token.with.kid2',
-      mockJWKS,
-      { algorithms: ['RS256'] }
-    )
-    expect(result).toStrictEqual(mockPayload)
   })
 })

--- a/src/server/auth/types/auth.js
+++ b/src/server/auth/types/auth.js
@@ -47,68 +47,18 @@
  */
 
 /**
- * Defra ID JWT payload structure from Azure B2C (production/test environments)
+ * Defra ID JWT payload, narrowed to the claims we consume.
+ *
+ * Real tokens carry many more claims (Azure B2C policy fields,
+ * `iss`/`aud`/`nbf`/`iat`, etc.); they're allowed through validation but not
+ * declared here so the type contract reflects what the codebase actually uses.
+ * Add a field here only when adding code that reads it, and validate it at the
+ * `verify-token` boundary at the same time.
  * @typedef {{
  *   sub: string
  *   email: string
- *   correlationId: string
- *   sessionId: string
- *   contactId: string
- *   serviceId: string
- *   firstName: string
- *   lastName: string
- *   uniqueReference: string
- *   loa: number
- *   aal: string
- *   enrolmentCount: number
- *   enrolmentRequestCount: number
- *   currentRelationshipId: string
- *   relationships: string[]
- *   roles?: string[]
  *   exp: number
- *   iat: number
- *   nbf: number
- *   iss: string
- *   aud: string
- *   ver?: string
- *   acr?: string
- *   auth_time?: number
- *   amr?: string
- * }} AzureB2CJwtPayload
- */
-
-/**
- * Defra ID JWT payload structure from stub (local development)
- * @typedef {{
- *   id: string
- *   sub: string
- *   aud: string
- *   iss: string
- *   nbf: number
- *   exp: number
- *   iat: number
- *   email: string
- *   correlationId: string
- *   sessionId: string
- *   contactId: string
- *   serviceId: string
- *   firstName: string
- *   lastName: string
- *   uniqueReference: string
- *   loa: string
- *   aal: string
- *   enrolmentCount: string
- *   enrolmentRequestCount: string
- *   currentRelationshipId: string
- *   relationships: string[]
- *   roles: string[]
- * }} StubJwtPayload
- */
-
-/**
- * Union type for all Defra ID JWT payload formats
- * Supports both Azure B2C (production) and stub (local dev) token structures
- * @typedef {AzureB2CJwtPayload | StubJwtPayload} DefraIdJwtPayload
+ * }} DefraIdJwtPayload
  */
 
 /**

--- a/src/server/auth/types/auth.js
+++ b/src/server/auth/types/auth.js
@@ -55,6 +55,10 @@
  * Add a field here only when adding code that reads it, and validate it at the
  * `verify-token` boundary at the same time.
  *
+ * For the full shape emitted by the local stub (the closest thing to an
+ * executable spec), see `generateDefraIdToken` in cdp-defra-id-stub:
+ * https://github.com/DEFRA/cdp-defra-id-stub/blob/main/src/server/oidc/helpers/generate-defraid-token.js
+ *
  * `email` is optional because the OIDC scope we request (`openid`,
  * `offline_access` — see src/server/auth/plugins/defra-id.js) does not include
  * `email`. Defra ID's B2C policy currently maps it into the id_token by

--- a/src/server/auth/types/auth.js
+++ b/src/server/auth/types/auth.js
@@ -55,8 +55,12 @@
  * Add a field here only when adding code that reads it, and validate it at the
  * `verify-token` boundary at the same time.
  *
- * For the full shape emitted by the local stub (the closest thing to an
- * executable spec), see `generateDefraIdToken` in cdp-defra-id-stub:
+ * For the full production payload shape, the authoritative reference is the
+ * Defra ID team's Confluence space:
+ * https://eaflood.atlassian.net/wiki/spaces/MWR/pages/5952995350/Defra+ID
+ *
+ * For a local, inspectable mirror of that shape, see `generateDefraIdToken`
+ * in cdp-defra-id-stub:
  * https://github.com/DEFRA/cdp-defra-id-stub/blob/main/src/server/oidc/helpers/generate-defraid-token.js
  *
  * `email` is optional because the OIDC scope we request (`openid`,

--- a/src/server/auth/types/auth.js
+++ b/src/server/auth/types/auth.js
@@ -54,9 +54,14 @@
  * declared here so the type contract reflects what the codebase actually uses.
  * Add a field here only when adding code that reads it, and validate it at the
  * `verify-token` boundary at the same time.
+ *
+ * `email` is optional because the OIDC scope we request (`openid`,
+ * `offline_access` — see src/server/auth/plugins/defra-id.js) does not include
+ * `email`. Defra ID's B2C policy currently maps it into the id_token by
+ * default, but that's a policy decision; downstream consumers handle absence.
  * @typedef {{
  *   sub: string
- *   email: string
+ *   email?: string
  *   exp: number
  * }} DefraIdJwtPayload
  */

--- a/src/server/auth/types/session.js
+++ b/src/server/auth/types/session.js
@@ -7,9 +7,12 @@
  *
  * Only includes fields actually used in production (for audit logging).
  * Other JWT claims are available but not stored as they're unused.
+ *
+ * `email` is optional because the Defra ID id_token doesn't guarantee its
+ * presence (the `email` scope isn't requested — see DefraIdJwtPayload).
  * @typedef {{
  *   id: string
- *   email: string
+ *   email?: string
  * }} UserProfile
  */
 

--- a/src/server/common/helpers/auditing/index.js
+++ b/src/server/common/helpers/auditing/index.js
@@ -1,13 +1,26 @@
 import { audit } from '@defra/cdp-auditing'
 
+/**
+ * @param {string} userId
+ * @param {string | undefined} userEmail
+ */
 function auditSignIn(userId, userEmail) {
   auditSSO('sign-in', userId, userEmail)
 }
 
+/**
+ * @param {string} userId
+ * @param {string | undefined} userEmail
+ */
 function auditSignOut(userId, userEmail) {
   auditSSO('sign-out', userId, userEmail)
 }
 
+/**
+ * @param {'sign-in' | 'sign-out'} action
+ * @param {string} userId
+ * @param {string | undefined} userEmail
+ */
 function auditSSO(action, userId, userEmail) {
   const payload = {
     event: {


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

`jose.jwtVerify` returns a loose `JWTPayload`, but the `VerifyToken` contract narrows it to `DefraIdJwtPayload`. Until now that narrowing was an implicit type-system claim with no runtime check.

This change adds a Joi schema at the `verify-token` boundary that validates the claims the codebase actually reads, and returns the validated value through the existing typed contract. Validation failure throws an error prefixed with `Invalid Defra ID JWT payload:` and the formatted Joi `error.details`, mirroring the `formatValidationErrorDetails` pattern in `epr-backend`'s `repositories/organisations/schema/validation.js` so an operator triaging a failed sign-in sees which field was rejected rather than Joi's default message.

## Scope of validation

The auth subsystem reads exactly three claims off the validated payload:

- `payload.sub` — `build-session.js:24` (used as the user id)
- `payload.email` — `build-session.js:25` (used in audit/profile)
- `payload.exp` — `build-session.js:11` via `getTokenExpiresAt`

The schema validates only those three, with `.unknown(true)` so every other claim Defra ID emits passes straight through. The `DefraIdJwtPayload` typedef is narrowed to match. This deliberately under-validates relative to what Defra ID sends so that upstream changes to claims we don't consume can't break sign-in or refresh.

`email` is **optional** in the schema and the typedef. The OIDC scope we request from Defra ID is `openid` + `offline_access` only — `email` is not requested. Defra ID's B2C policy currently maps it into the id_token by default for our serviceId, but that's a policy-side decision; if it ever changes, requiring email at the verify-token boundary would lock every user out of sign-in. Marking it optional propagates through `UserProfile.email` and the `auditSignIn` / `auditSignOut` signatures so callers see that absence is possible.

The previous typedef declared a full `AzureB2C | Stub` union with ~25 fields. The stub branch was also wrong about types — the real `cdp-defra-id-stub` emits `loa`, `aal`, `enrolmentCount` and `enrolmentRequestCount` as numbers, matching the B2C shape rather than the strings the typedef declared — so the union's stub branch was effectively dead. Both are removed.

## What changed

- **`src/server/auth/types/auth.js`**: `DefraIdJwtPayload` narrowed to `{ sub, email?, exp }`. `AzureB2CJwtPayload` and `StubJwtPayload` deleted (unused outside this file).
- **`src/server/auth/types/session.js`**: `UserProfile.email` made optional to match.
- **`src/server/auth/helpers/defra-id-jwt-schema.js`** (new): three-field Joi schema (`sub` and `exp` required, `email` optional) with `.unknown(true)` and a thin `validateDefraIdJwtPayload` wrapper that throws on failure with formatted error details.
- **`src/server/auth/helpers/verify-token.js`**: pipes the `jose.jwtVerify` payload through the validator instead of returning it directly.
- **`src/server/common/helpers/auditing/index.js`**: `auditSignIn` and `auditSignOut` signatures declare email as `string | undefined`.
- **`src/server/auth/helpers/verify-token.test.js`**: tests cover accepts-with-extras, accepts-without-email, throws on missing required claim.

Closes part of PAE-1339 (the `verify-token.js` slice). One pre-existing type error eliminated; no new errors introduced; the remaining errors in the repo are unrelated and tracked separately.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ