### PR TITLE
PAE-1339: Advertise TypedLogger on HapiRequest and HapiServer

### DIFF
--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -4,6 +4,7 @@
  * @import {Policy, PolicyOptions} from '@hapi/catbox'
  * @import {TFunction, i18n} from 'i18next'
  * @import {Metrics} from '@defra/cdp-metrics'
+ * @import {TypedLogger} from './helpers/logging/logger.js'
  * @import {WasteOrganisationsService} from './helpers/waste-organisations/port.js'
  * @import {UserSession} from '../auth/types/session.js'
  */
@@ -47,8 +48,18 @@
  */
 
 /**
- * Hapi server with our application state typed.
- * @typedef {Omit<Server, 'app'> & { app: AppState }} HapiServer
+ * Hapi server with our application state and the CDP-compliant typed logger.
+ * Intersecting `logger` with `TypedLogger` advertises the
+ * `IndexedLogProperties` shape alongside the broader `pino.Logger` that
+ * hapi-pino contributes, so `server.logger.*` call-sites get the CDP
+ * Elasticsearch allow-list surfaced in IDE hints. It does not hard-enforce
+ * the allow-list — pino's `(obj: object, msg?) => void` overload remains
+ * reachable through the intersection. Use `createLogger()` directly where
+ * strict narrowing is required.
+ * @typedef {Omit<Server, 'app'> & {
+ *   app: AppState,
+ *   logger: TypedLogger
+ * }} HapiServer
  */
 
 /**
@@ -78,8 +89,15 @@
  *   - `state.userSession` narrowed to the cookie state written by the
  *     session strategy
  *   - `yar.flash` extended with the flash keys the app uses
+ *   - `logger` intersected with `TypedLogger` so object-form log calls get
+ *     the CDP `IndexedLogProperties` shape advertised in IDE hints without
+ *     losing the rest of the pino logger surface hapi-pino contributes.
+ *     The intersection does not hard-enforce the allow-list — pino's
+ *     `(obj: object, msg?) => void` overload remains reachable. Use
+ *     `createLogger()` directly where strict narrowing is required.
  * @typedef {Omit<Request, 'auth' | 'server' | 'state' | 'yar'> & {
  *   auth: RequestAuth,
+ *   logger: TypedLogger,
  *   server: HapiServer,
  *   state: Request['state'] & { userSession?: SessionCookieState },
  *   yar: HapiYar,

--- a/src/server/common/helpers/logging/logger.js
+++ b/src/server/common/helpers/logging/logger.js
@@ -23,13 +23,20 @@ import { loggerOptions } from '#server/common/helpers/logging/logger-options.js'
  */
 
 /**
+ * Pino's log methods accept either a message string or an indexed-properties
+ * object (optionally followed by a message). Expressed as an intersection of
+ * call signatures so both overloads are visible to the type checker.
+ * @typedef {((msg: string) => void) & ((obj: IndexedLogProperties, msg?: string) => void)} LogMethod
+ */
+
+/**
  * @typedef {object} TypedLogger
- * @property {(obj: IndexedLogProperties, msg?: string) => void} info
- * @property {(obj: IndexedLogProperties, msg?: string) => void} error
- * @property {(obj: IndexedLogProperties, msg?: string) => void} warn
- * @property {(obj: IndexedLogProperties, msg?: string) => void} debug
- * @property {(obj: IndexedLogProperties, msg?: string) => void} trace
- * @property {(obj: IndexedLogProperties, msg?: string) => void} fatal
+ * @property {LogMethod} info
+ * @property {LogMethod} error
+ * @property {LogMethod} warn
+ * @property {LogMethod} debug
+ * @property {LogMethod} trace
+ * @property {LogMethod} fatal
  */
 
 /**


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

Advertises the CDP-compliant `TypedLogger` shape on `request.logger` and `server.logger` in the frontend, mirroring the pattern already in use in `epr-backend/src/common/hapi-types.js`. Two pieces are bundled on this branch to keep the logger typing changes together.

**`TypedLogger` gains an explicit string-message overload.** The typedef in `src/server/common/helpers/logging/logger.js` now expresses Pino's dual call shape via a shared `LogMethod`: `(msg: string) => void` intersected with `(obj: IndexedLogProperties, msg?: string) => void`. The object-first overload still restricts `obj` to `IndexedLogProperties`, so callers cannot bypass the indexed-field allow-list via this change. Clears pre-existing TS2559 errors at `logger.info('some message')` sites that Pino accepts at runtime but the typed wrapper was rejecting.

**`HapiRequest` and `HapiServer` carry `logger: TypedLogger`.** `src/server/common/hapi-types.js` now intersects the hapi-pino-contributed `logger` with `TypedLogger`, so IDE hints surface the `IndexedLogProperties` shape alongside Pino's own overloads.

The intersection advertises the CDP allow-list shape but does not hard-enforce it at `request.logger.*` / `server.logger.*` call-sites — Pino's `(obj: object, msg?) => void` overload remains reachable through the intersection. JSDoc on each typedef documents the limitation and points future readers at `createLogger()` for strict narrowing. Real call-site enforcement is deferred to a separate slice.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ