### PR TITLE
PAE-1366: add eqeqeq rule and is-nil helper

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,7 @@ export default [
     rules: {
       '@typescript-eslint/no-floating-promises': ['error'],
       '@typescript-eslint/return-await': ['error', 'in-try-catch'],
+      eqeqeq: ['error', 'always'],
       'no-console': 'error',
       'object-shorthand': ['error', 'properties'],
       // Turn off strict type checking rules

--- a/src/server/common/helpers/is-nil.js
+++ b/src/server/common/helpers/is-nil.js
@@ -1,3 +1,7 @@
+/**
+ * @param {unknown} value
+ * @returns {value is null | undefined}
+ */
 const isNil = (value) => value === null || value === undefined
 
 export { isNil }

--- a/src/server/common/helpers/is-nil.js
+++ b/src/server/common/helpers/is-nil.js
@@ -1,0 +1,3 @@
+const isNil = (value) => value === null || value === undefined
+
+export { isNil }

--- a/src/server/common/helpers/is-nil.test.js
+++ b/src/server/common/helpers/is-nil.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { isNil } from './is-nil.js'
+
+describe(isNil, () => {
+  it('should return true for null', () => {
+    expect(isNil(null)).toBe(true)
+  })
+
+  it('should return true for undefined', () => {
+    expect(isNil(undefined)).toBe(true)
+  })
+
+  it.each([
+    { value: 0, label: '0' },
+    { value: '', label: 'empty string' },
+    { value: false, label: 'false' },
+    { value: NaN, label: 'NaN' },
+    { value: {}, label: 'empty object' },
+    { value: [], label: 'empty array' }
+  ])('should return false for $label', ({ value }) => {
+    expect(isNil(value)).toBe(false)
+  })
+})

--- a/src/server/prns/view-controller.js
+++ b/src/server/prns/view-controller.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 
+import { isNil } from '#server/common/helpers/is-nil.js'
 import { getRequiredRegistrationWithAccreditation } from '#server/common/helpers/organisations/get-required-registration-with-accreditation.js'
 import { getNoteTypeDisplayNames } from '#server/common/helpers/prns/registration-helpers.js'
 import { fetchWasteBalances } from '#server/common/helpers/waste-balance/fetch-waste-balances.js'
@@ -363,7 +364,7 @@ function buildExistingPrnViewData({
     heading: noteTypeFull,
     showRegulatorLogos: isNotDraft,
     complianceYearText:
-      isNotDraft && prn.accreditationYear != null
+      isNotDraft && !isNil(prn.accreditationYear)
         ? localise('prns:view:complianceYearText', {
             noteType,
             wasteAction,

--- a/src/server/reports/helpers/validation.js
+++ b/src/server/reports/helpers/validation.js
@@ -1,6 +1,8 @@
 import { Decimal } from 'decimal.js'
 import Joi from 'joi'
 
+import { isNil } from '#server/common/helpers/is-nil.js'
+
 const TWO_DECIMAL_PLACES = 2
 
 /**
@@ -9,7 +11,7 @@ const TWO_DECIMAL_PLACES = 2
  * @returns {string}
  */
 export const padToTwoDecimalPlaces = (value) => {
-  if (value !== null && value !== undefined) {
+  if (!isNil(value)) {
     return Number.isInteger(value)
       ? String(value)
       : value.toFixed(TWO_DECIMAL_PLACES)


### PR DESCRIPTION
Ticket: [PAE-1366](https://eaflood.atlassian.net/browse/PAE-1366)
add strict eqeqeq eslint rule and isNil type guard helper to replace loose equality checks against null/undefined

- add `eqeqeq: ['error', 'always']` to eslint config
- add `isNil` helper with JSDoc type predicate for type narrowing
- replace `!= null` and `!== null && !== undefined` patterns with `isNil`

[PAE-1366]: https://eaflood.atlassian.net/browse/PAE-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ