### PR TITLE
PAE-000: pass sonar.branch.name on push to fix ce task

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -143,3 +143,4 @@ runs:
       with:
         args: >
           -Dsonar.qualitygate.wait=true
+          ${{ github.event_name == 'push' && format('-Dsonar.branch.name={0}', github.ref_name) || '' }}

--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -143,4 +143,4 @@ runs:
       with:
         args: >
           -Dsonar.qualitygate.wait=true
-          ${{ github.event_name == 'push' && format('-Dsonar.branch.name={0}', github.ref_name) || '' }}
+          ${{ github.event_name != 'pull_request' && format('-Dsonar.branch.name={0}', github.ref_name) || '' }}


### PR DESCRIPTION
main is blocked by a failing SonarQube check - which is confused about the main branch for some reason.

> Project or branch in report (DEFRA_epr-frontend) does not match the project or branch under which it was submitted (DEFRA_epr-frontend:BRANCH:main)

this somewhat speculative fix passes the branch for non-PRs

---

pass `sonar.branch.name` to the sonar scan on push-to-main so the submitted report matches the project:branch context on sonarcloud's side.

- main has been red since 2026-04-15 with `ce task finished abnormally`; sonarcloud reports `project or branch in report (defra_epr-frontend) does not match the project or branch under which it was submitted (defra_epr-frontend:branch:main)`
- scan-action@v7 auto-detects pr context correctly (pr checks still green) but does not set `sonar.branch.name` on push events, so the submitted report has no branch while the server context does
- conditional on `github.event_name == 'push'` so pr scans keep their existing auto-detection
