### PR TITLE
PAE-000: revert sonar scan-action to v6 to unblock main

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -136,11 +136,10 @@ runs:
 
     - name: SonarCloud Scan
       if: ${{ github.actor != 'dependabot[bot]' }}
-      uses: SonarSource/sonarqube-scan-action@v7
+      uses: SonarSource/sonarqube-scan-action@v6
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         SONAR_TOKEN: ${{ inputs.sonar-token }}
       with:
         args: >
           -Dsonar.qualitygate.wait=true
-          ${{ github.event_name != 'pull_request' && format('-Dsonar.branch.name={0}', github.ref_name) || '' }}


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)

revert `sonarqube-scan-action` from `@v7` back to `@v6` to match `epr-backend` and `epr-re-ex-admin-frontend` (both green on main).

- main has been red since 2026-04-15 with `ce task finished abnormally`; sonarcloud: `project or branch in report (defra_epr-frontend) does not match the project or branch under which it was submitted (defra_epr-frontend:branch:main)`
- scan-action v7 bundles sonar-scanner-cli 8.0.1.6346, whose push-to-main reports are not accepted by sonarcloud's ce after a server-side change around 2026-04-15
- prior fix (pr #783) adding `-Dsonar.branch.name=main` made the scanner log `Branch name: main, type: long-lived` but the ce rejection was unchanged -- the scanner-8.0 report format does not embed the branch the way the ce now expects, so cli flags cannot work around it
- scan-action v6 (scanner-cli 7.x) is a known-good configuration in use by the sibling repos