### PR TITLE
PAE-1339: Apply HapiRequest typedef to nunjucks context and error helpers

### DIFF
--- a/src/config/nunjucks/context/build-navigation.js
+++ b/src/config/nunjucks/context/build-navigation.js
@@ -1,24 +1,12 @@
 import { config } from '#config/config.js'
 
 /**
- * @import { UserSession } from '#server/auth/types/session.js'
- */
-
-/**
- * I18nRequest - Request object with i18n helpers
- * @typedef {Partial<Request> & {
- *  localiseUrl: (url: string) => string;
- *  t: (key: string) => string
- * }} I18nRequest
- */
-
-/**
  * Navigation item
  * @typedef {{active?: boolean, href: string, text: string}} NavigationItem
  */
 
 /**
- * @param {I18nRequest} request
+ * @param {HapiRequest} request
  * @param {UserSession} session
  * @returns {NavigationItem[]}
  */
@@ -35,7 +23,7 @@ const home = ({ localiseUrl, t: localise }, session) => {
 }
 
 /**
- * @param {I18nRequest} request
+ * @param {HapiRequest} request
  * @returns {NavigationItem[]}
  */
 const manageAccount = ({ t: localise }) => {
@@ -48,7 +36,7 @@ const manageAccount = ({ t: localise }) => {
 }
 
 /**
- * @param {I18nRequest} request
+ * @param {HapiRequest} request
  * @returns {NavigationItem[]}
  */
 const signOut = ({ localiseUrl, t: localise }) => {
@@ -61,7 +49,7 @@ const signOut = ({ localiseUrl, t: localise }) => {
 }
 
 /**
- * @param {I18nRequest | null} request
+ * @param {HapiRequest | null} request
  */
 export function buildNavigation(request) {
   if (!request) {
@@ -82,5 +70,6 @@ export function buildNavigation(request) {
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { UserSession } from '#server/auth/types/session.js'
  */

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -17,7 +17,7 @@ let webpackManifest
 /**
  * Extract i18n properties from request for template context
  * Only includes properties if i18n is available on the request
- * @param {Request | null} request
+ * @param {HapiRequest | null} request
  */
 const getI18nContext = (request) => {
   if (!request?.i18n) {
@@ -41,7 +41,7 @@ const getI18nContext = (request) => {
 }
 
 /**
- * @param {Request | null} request
+ * @param {HapiRequest | null} request
  */
 export function context(request) {
   if (!webpackManifest) {
@@ -73,5 +73,5 @@ export function context(request) {
 }
 
 /**
- * @import { Request } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -36,7 +36,7 @@ function statusCodeMessage(statusCode, localise) {
 }
 
 /**
- * @param { Request } request
+ * @param { HapiRequest } request
  * @param { ResponseToolkit } h
  */
 export async function catchAll(request, h) {
@@ -70,5 +70,6 @@ export async function catchAll(request, h) {
 }
 
 /**
- * @import { Request, ResponseToolkit } from '@hapi/hapi'
+ * @import { ResponseToolkit } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Annotates the template context renderer, navigation builder, and `catchAll` onPreResponse error handler with the `HapiRequest` JSDoc typedef from `src/server/common/hapi-types.js` instead of the raw `@hapi/hapi` `Request` type.

All three receive the live request decorated by our registered plugins (`t`, `i18n`, `localiseUrl`, `auth.credentials` narrowed to `UserSession`), so the narrower typedef matches runtime reality and clears 10 `lint:types` errors without adding runtime guards or `any` casts.

## Changes

- `src/config/nunjucks/context/context.js` — `context()` and the internal `getI18nContext()` helper now accept `HapiRequest | null`.
- `src/config/nunjucks/context/build-navigation.js` — navigation helpers now accept `HapiRequest`. The ad-hoc `I18nRequest` typedef (previously a `Partial<Request>` intersection) is removed; `HapiRequest` supersedes it and additionally narrows `auth.credentials` to `UserSession`, resolving the `UserSession` mismatch error that `I18nRequest` left uncovered.
- `src/server/common/helpers/errors.js` — `catchAll` now accepts `HapiRequest`.

No TypeScript files introduced. No `any` casts. No runtime null guards added.

`npm run lint:types`: 51 → 41 errors remaining (this slice clears all errors in the three files touched).

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ