### PR TITLE
PAE-1369: restore sonar scan-action v7

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -136,7 +136,7 @@ runs:
 
     - name: SonarCloud Scan
       if: ${{ github.actor != 'dependabot[bot]' }}
-      uses: SonarSource/sonarqube-scan-action@v6
+      uses: SonarSource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         SONAR_TOKEN: ${{ inputs.sonar-token }}


### PR DESCRIPTION
Ticket: [PAE-1369](https://eaflood.atlassian.net/browse/PAE-1369)

restore `SonarSource/sonarqube-scan-action` from `@v6` back to `@v7`.

[PAE-1369]: https://eaflood.atlassian.net/browse/PAE-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ