### PR TITLE
PAE-1339: Apply HapiRequest typedef across the summary-log subsystem

### DIFF
--- a/src/domain/summary-logs/meta-fields.js
+++ b/src/domain/summary-logs/meta-fields.js
@@ -13,6 +13,7 @@ export const PROCESSING_TYPES = Object.freeze({
 
 /** @typedef {typeof PROCESSING_TYPES[keyof typeof PROCESSING_TYPES]} ProcessingType */
 
+/** @type {Set<ProcessingType>} */
 export const REGISTERED_ONLY_PROCESSING_TYPES = new Set([
   PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
   PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY

--- a/src/domain/summary-logs/meta-fields.js
+++ b/src/domain/summary-logs/meta-fields.js
@@ -13,7 +13,6 @@ export const PROCESSING_TYPES = Object.freeze({
 
 /** @typedef {typeof PROCESSING_TYPES[keyof typeof PROCESSING_TYPES]} ProcessingType */
 
-/** @type {Set<ProcessingType>} */
 export const REGISTERED_ONLY_PROCESSING_TYPES = new Set([
   PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
   PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY

--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -25,9 +25,36 @@ import { fetchWasteBalances } from '#server/common/helpers/waste-balance/fetch-w
  *   RawLoads,
  *   RawLoadsByWasteRecordType,
  *   RegisteredOnlyLoadsSectionViewModel,
+ *   SummaryLogParams,
  *   SummaryLogStatusResponse,
+ *   SummaryLogsSession,
  *   ValidationResponse
  * } from './types.js'
+ */
+
+/**
+ * @typedef {'EXPORTER_REGISTERED_ONLY' | 'REPROCESSOR_REGISTERED_ONLY'} RegisteredOnlyProcessingType
+ */
+
+/**
+ * Context passed to every view resolver. Fields populated depend on the
+ * backend status, so all data-bearing properties are optional and each
+ * resolver destructures only what it needs.
+ * @typedef {{
+ *   status: string,
+ *   validation?: ValidationResponse,
+ *   accreditationNumber?: string,
+ *   loads?: RawLoads,
+ *   loadsByWasteRecordType?: RawLoadsByWasteRecordType,
+ *   processingType?: ProcessingType,
+ *   organisationId: string,
+ *   registrationId: string,
+ *   summaryLogId: string,
+ *   pollUrl: string,
+ *   uploadUrl?: string,
+ *   cancelUrl: string,
+ *   wasteBalance?: number
+ * }} RenderContext
  */
 
 const SECTION_BY_PROCESSING_TYPE_AND_WASTE_RECORD_TYPE = Object.freeze({
@@ -87,8 +114,18 @@ const REUPLOAD_STATES = new Set([
  * @returns {number | undefined} Waste record section number (1 or 3)
  */
 export const getWasteRecordSectionNumber = (processingType) => {
-  return WASTE_RECORD_SECTION_BY_PROCESSING_TYPE[processingType]
+  return processingType === undefined
+    ? undefined
+    : WASTE_RECORD_SECTION_BY_PROCESSING_TYPE[processingType]
 }
+
+/**
+ * @param {ProcessingType} [processingType]
+ * @returns {processingType is RegisteredOnlyProcessingType}
+ */
+const isRegisteredOnlyProcessingType = (processingType) =>
+  processingType !== undefined &&
+  REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)
 
 const VIEW_NAME = 'summary-log/progress'
 const CHECK_VIEW_NAME = 'summary-log/check'
@@ -210,7 +247,7 @@ const getProgressViewData = (localise, status) => {
 
 /**
  * Gets status data from session (if fresh) or backend API
- * @param {object} request - Hapi request object
+ * @param {HapiRequest} request - Hapi request object
  * @param {string} organisationId - Organisation ID
  * @param {string} registrationId - Registration ID
  * @param {string} summaryLogId - Summary log ID
@@ -224,7 +261,9 @@ const getStatusData = async (
   summaryLogId,
   idToken
 ) => {
-  const summaryLogsSession = request.yar.get(sessionNames.summaryLogs) || {}
+  /** @type {SummaryLogsSession | null} */
+  const storedSession = request.yar.get(sessionNames.summaryLogs)
+  const summaryLogsSession = storedSession ?? {}
   const freshData = summaryLogsSession.freshDataMap?.[summaryLogId]
 
   const data =
@@ -233,7 +272,7 @@ const getStatusData = async (
       idToken
     }))
 
-  if (freshData) {
+  if (freshData && summaryLogsSession.freshDataMap) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [summaryLogId]: _, ...remainingMap } =
       summaryLogsSession.freshDataMap
@@ -263,17 +302,17 @@ const getStatusData = async (
 }
 
 /**
- * Renders the check page for validated summary logs
- * @param {object} h - Hapi response toolkit
+ * Renders the check page for validated summary logs.
+ *
+ * The registered-only branch requires both a registered-only processing
+ * type and a populated loadsByWasteRecordType. Both are guaranteed to be
+ * present together once the backend has validated a registered-only
+ * submission; the guard below protects against partial data from the
+ * validated-state fetch while keeping types honest.
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {RawLoads} context.loads - Load statistics for the summary log
- * @param {RawLoadsByWasteRecordType} [context.loadsByWasteRecordType] - Per-waste-record-type load breakdowns
- * @param {string} context.organisationId - Organisation ID
- * @param {string} context.registrationId - Registration ID
- * @param {string} context.summaryLogId - Summary log ID
- * @param {ProcessingType} [context.processingType] - Processing type from summary log meta
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderCheckView = (
   h,
@@ -287,7 +326,10 @@ const renderCheckView = (
     processingType
   }
 ) => {
-  if (REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)) {
+  if (
+    isRegisteredOnlyProcessingType(processingType) &&
+    loadsByWasteRecordType !== undefined
+  ) {
     return h.view('summary-log/check-registered-only', {
       pageTitle: localise('summary-log:checkPageTitle'),
       organisationId,
@@ -316,11 +358,10 @@ const renderCheckView = (
 
 /**
  * Renders the submitting page while submission is in progress
- * @param {object} h - Hapi response toolkit
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {string} context.pollUrl - URL for polling submission status
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderSubmittingView = (h, localise, { pollUrl }) => {
   return h.view(SUBMITTING_VIEW_NAME, {
@@ -335,12 +376,10 @@ const renderSubmittingView = (h, localise, { pollUrl }) => {
 
 /**
  * Renders the success page after successful submission
- * @param {object} h - Hapi response toolkit
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {string} context.organisationId - Organisation ID
- * @param {number} [context.wasteBalance] - Available waste balance in tonnes
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderSuccessView = (h, localise, { organisationId, wasteBalance }) => {
   return h.view(SUCCESS_VIEW_NAME, {
@@ -352,12 +391,10 @@ const renderSuccessView = (h, localise, { organisationId, wasteBalance }) => {
 
 /**
  * Renders the superseded page for summary logs replaced by a newer upload
- * @param {object} h - Hapi response toolkit
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {string} context.organisationId - Organisation ID
- * @param {string} context.registrationId - Registration ID
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderSupersededView = (
   h,
@@ -373,13 +410,10 @@ const renderSupersededView = (
 
 /**
  * Renders the validation failures page for invalid summary logs
- * @param {object} h - Hapi response toolkit
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string, params?: object) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {ValidationResponse} context.validation - Validation result containing failures
- * @param {string} context.uploadUrl - URL for re-uploading the file
- * @param {string} context.cancelUrl - URL for cancelling and returning to home
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderValidationFailuresView = (
   h,
@@ -439,12 +473,10 @@ const renderValidationFailuresView = (
 
 /**
  * Renders the progress page for processing states or unexpected statuses
- * @param {object} h - Hapi response toolkit
+ * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {object} context - View context
- * @param {string} context.status - Current summary log status
- * @param {string} context.pollUrl - URL for polling status updates
- * @returns {object} Hapi view response
+ * @param {RenderContext} context - View context
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderProgressView = (h, localise, { status, pollUrl }) => {
   const viewData = getProgressViewData(localise, status)
@@ -459,6 +491,11 @@ const renderProgressView = (h, localise, { status, pollUrl }) => {
 
 /**
  * View resolver mapping - maps backend statuses to their render functions
+ * @type {Record<string, (
+ *   h: ResponseToolkit,
+ *   localise: (key: string, params?: object) => string,
+ *   context: RenderContext
+ * ) => ReturnType<ResponseToolkit['view']>>}
  */
 const viewResolvers = {
   [summaryLogStatuses.validated]: renderCheckView,
@@ -473,21 +510,11 @@ const viewResolvers = {
 
 /**
  * Renders appropriate view based on status
- * @param {object} options - Rendering options
- * @param {object} options.h - Hapi response toolkit
- * @param {(key: string, params?: object) => string} options.localise - i18n localisation function
- * @param {string} options.status - Backend status
- * @param {ValidationResponse} [options.validation] - Validation object from backend
- * @param {string} [options.accreditationNumber] - Accreditation number for submitted logs
- * @param {RawLoads} [options.loads] - Loads data with row IDs for validated summary logs
- * @param {RawLoadsByWasteRecordType} [options.loadsByWasteRecordType] - Per-waste-record-type load breakdowns
- * @param {string} options.organisationId - Organisation ID
- * @param {string} options.registrationId - Registration ID
- * @param {string} options.summaryLogId - Summary log ID
- * @param {string} options.pollUrl - URL for polling status
- * @param {string} options.uploadUrl - URL for re-uploading
- * @param {string} options.cancelUrl - URL for cancel button
- * @returns {object} Hapi view response
+ * @param {{
+ *   h: ResponseToolkit,
+ *   localise: (key: string, params?: object) => string
+ * } & RenderContext} options - Rendering options
+ * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
  */
 const renderViewForStatus = (options) => {
   const { h, localise, status } = options
@@ -583,6 +610,10 @@ const getWasteBalanceData = async (
  * @satisfies {Partial<ServerRoute>}
  */
 export const summaryLogUploadProgressController = {
+  /**
+   * @param {HapiRequest & { params: SummaryLogParams }} request
+   * @param {ResponseToolkit} h
+   */
   handler: async (request, h) => {
     const localise = request.t
     const { organisationId, registrationId, summaryLogId } = request.params
@@ -646,5 +677,6 @@ export const summaryLogUploadProgressController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -1,7 +1,4 @@
-import {
-  PROCESSING_TYPES,
-  REGISTERED_ONLY_PROCESSING_TYPES
-} from '#domain/summary-logs/meta-fields.js'
+import { PROCESSING_TYPES } from '#domain/summary-logs/meta-fields.js'
 import { WASTE_RECORD_TYPE } from '#domain/waste-records/model.js'
 import { sessionNames } from '#server/common/constants/session-names.js'
 import { summaryLogStatuses } from '#server/common/constants/statuses.js'
@@ -124,8 +121,8 @@ export const getWasteRecordSectionNumber = (processingType) => {
  * @returns {processingType is RegisteredOnlyProcessingType}
  */
 const isRegisteredOnlyProcessingType = (processingType) =>
-  processingType !== undefined &&
-  REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)
+  processingType === PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY ||
+  processingType === PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY
 
 const VIEW_NAME = 'summary-log/progress'
 const CHECK_VIEW_NAME = 'summary-log/check'
@@ -264,7 +261,8 @@ const getStatusData = async (
   /** @type {SummaryLogsSession | null} */
   const storedSession = request.yar.get(sessionNames.summaryLogs)
   const summaryLogsSession = storedSession ?? {}
-  const freshData = summaryLogsSession.freshDataMap?.[summaryLogId]
+  const freshDataMap = summaryLogsSession.freshDataMap
+  const freshData = freshDataMap?.[summaryLogId]
 
   const data =
     freshData ??
@@ -272,10 +270,9 @@ const getStatusData = async (
       idToken
     }))
 
-  if (freshData && summaryLogsSession.freshDataMap) {
+  if (freshDataMap !== undefined && summaryLogId in freshDataMap) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { [summaryLogId]: _, ...remainingMap } =
-      summaryLogsSession.freshDataMap
+    const { [summaryLogId]: _, ...remainingMap } = freshDataMap
     request.yar.set(sessionNames.summaryLogs, {
       ...summaryLogsSession,
       freshDataMap: remainingMap
@@ -302,17 +299,15 @@ const getStatusData = async (
 }
 
 /**
- * Renders the check page for validated summary logs.
- *
- * The registered-only branch requires both a registered-only processing
- * type and a populated loadsByWasteRecordType. Both are guaranteed to be
- * present together once the backend has validated a registered-only
- * submission; the guard below protects against partial data from the
- * validated-state fetch while keeping types honest.
+ * Renders the check page for validated summary logs. A registered-only
+ * processing type is always paired with loadsByWasteRecordType by the
+ * backend; if that invariant breaks we throw rather than silently
+ * falling through to the non-registered view, which would render a
+ * misleading empty page.
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderCheckView = (
   h,
@@ -326,10 +321,12 @@ const renderCheckView = (
     processingType
   }
 ) => {
-  if (
-    isRegisteredOnlyProcessingType(processingType) &&
-    loadsByWasteRecordType !== undefined
-  ) {
+  if (isRegisteredOnlyProcessingType(processingType)) {
+    if (loadsByWasteRecordType === undefined) {
+      throw new Error(
+        `Expected loadsByWasteRecordType for registered-only processing type ${processingType}`
+      )
+    }
     return h.view('summary-log/check-registered-only', {
       pageTitle: localise('summary-log:checkPageTitle'),
       organisationId,
@@ -361,7 +358,7 @@ const renderCheckView = (
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderSubmittingView = (h, localise, { pollUrl }) => {
   return h.view(SUBMITTING_VIEW_NAME, {
@@ -379,7 +376,7 @@ const renderSubmittingView = (h, localise, { pollUrl }) => {
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderSuccessView = (h, localise, { organisationId, wasteBalance }) => {
   return h.view(SUCCESS_VIEW_NAME, {
@@ -394,7 +391,7 @@ const renderSuccessView = (h, localise, { organisationId, wasteBalance }) => {
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderSupersededView = (
   h,
@@ -413,7 +410,7 @@ const renderSupersededView = (
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string, params?: object) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderValidationFailuresView = (
   h,
@@ -476,7 +473,7 @@ const renderValidationFailuresView = (
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
  * @param {RenderContext} context - View context
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderProgressView = (h, localise, { status, pollUrl }) => {
   const viewData = getProgressViewData(localise, status)
@@ -495,7 +492,7 @@ const renderProgressView = (h, localise, { status, pollUrl }) => {
  *   h: ResponseToolkit,
  *   localise: (key: string, params?: object) => string,
  *   context: RenderContext
- * ) => ReturnType<ResponseToolkit['view']>>}
+ * ) => ResponseObject>}
  */
 const viewResolvers = {
   [summaryLogStatuses.validated]: renderCheckView,
@@ -514,7 +511,7 @@ const viewResolvers = {
  *   h: ResponseToolkit,
  *   localise: (key: string, params?: object) => string
  * } & RenderContext} options - Rendering options
- * @returns {ReturnType<ResponseToolkit['view']>} Hapi view response
+ * @returns {ResponseObject} Hapi view response
  */
 const renderViewForStatus = (options) => {
   const { h, localise, status } = options
@@ -677,6 +674,6 @@ export const summaryLogUploadProgressController = {
 }
 
 /**
- * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { ResponseObject, ResponseToolkit, ServerRoute } from '@hapi/hapi'
  * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/summary-log/controller.test.js
+++ b/src/server/summary-log/controller.test.js
@@ -2729,4 +2729,24 @@ describe('registered-only check view', () => {
       )
     ).toBeDefined()
   })
+
+  it('status: validated with registered-only processing type but missing loadsByWasteRecordType - should surface an error rather than silently render an empty page', async ({
+    server
+  }) => {
+    fetchSummaryLogStatus.mockResolvedValueOnce({
+      status: summaryLogStatuses.validated,
+      processingType: 'EXPORTER_REGISTERED_ONLY'
+    })
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url,
+      auth: mockAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.internalServerError)
+    expect(result).toStrictEqual(
+      expect.stringContaining('Something went wrong')
+    )
+  })
 })

--- a/src/server/summary-log/submit-controller.js
+++ b/src/server/summary-log/submit-controller.js
@@ -9,13 +9,19 @@ const PAGE_TITLE_KEY = 'summary-log:pageTitle'
  * @satisfies {Partial<ServerRoute>}
  */
 export const submitSummaryLogController = {
+  /**
+   * @param {HapiRequest & { params: SummaryLogParams }} request
+   * @param {ResponseToolkit} h
+   */
   handler: async (request, h) => {
     const localise = request.t
     const { organisationId, registrationId, summaryLogId } = request.params
 
     const redirectUrl = `/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}`
 
-    const summaryLogsSession = request.yar.get(sessionNames.summaryLogs) || {}
+    /** @type {SummaryLogsSession | null} */
+    const storedSession = request.yar.get(sessionNames.summaryLogs)
+    const summaryLogsSession = storedSession ?? {}
 
     if (summaryLogsSession.freshDataMap?.[summaryLogId]) {
       return h.redirect(redirectUrl)
@@ -54,5 +60,7 @@ export const submitSummaryLogController = {
 }
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
+ * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { SummaryLogParams, SummaryLogsSession } from './types.js'
  */

--- a/src/server/summary-log/types.js
+++ b/src/server/summary-log/types.js
@@ -95,4 +95,23 @@
  * }} SummaryLogStatusResponse
  */
 
+/**
+ * Route params for summary-log controllers.
+ * @typedef {{
+ *   organisationId: string,
+ *   registrationId: string,
+ *   summaryLogId: string
+ * }} SummaryLogParams
+ */
+
+/**
+ * Session data persisted under `sessionNames.summaryLogs`. `freshDataMap`
+ * holds status responses written by submitSummaryLogController that
+ * summaryLogUploadProgressController reads on the next request to bridge
+ * backend replication lag.
+ * @typedef {{
+ *   freshDataMap?: Record<string, SummaryLogStatusResponse>
+ * }} SummaryLogsSession
+ */
+
 export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Fixes 12 pre-existing `npm run lint:types` errors in the summary-log subsystem (51 → 39 remaining overall), following the incremental approach established in PRs [#774](https://github.com/DEFRA/epr-frontend/pull/774), [#775](https://github.com/DEFRA/epr-frontend/pull/775) and [#776](https://github.com/DEFRA/epr-frontend/pull/776).

## What changed

- **`src/server/summary-log/controller.js`** — annotates `summaryLogUploadProgressController.handler` and `getStatusData` with `HapiRequest & { params: SummaryLogParams }` and `ResponseToolkit`. Introduces a `RenderContext` typedef shared by every view resolver so the `renderViewForStatus` dispatcher compiles without widening to `any`. Adds an `isRegisteredOnlyProcessingType` type guard using direct equality against `PROCESSING_TYPES`.
- **`src/server/summary-log/submit-controller.js`** — applies the same `HapiRequest` pattern to `submitSummaryLogController.handler` and types the yar session read via `SummaryLogsSession`.
- **`src/server/summary-log/types.js`** — adds `SummaryLogParams` and `SummaryLogsSession` typedefs.
- **`src/server/summary-log/controller.test.js`** — covers the invariant-violation path where a registered-only processing type arrives without `loadsByWasteRecordType`.

## Why

`renderCheckView` previously crashed inside `buildLoadsByWasteRecordTypeViewModel.filter` when a registered-only `processingType` arrived without `loadsByWasteRecordType`. The invariant is now explicit — if the backend breaks it, the handler throws a named error and the user sees a 500 page rather than a silent `TypeError`. The `RenderContext` typedef also tightens the dispatcher, so adding a new status-to-view mapping is caught at type-check time rather than at runtime.

No suppressions, no `any` casts, no TypeScript files — JSDoc annotations only.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ