### PR TITLE
PAE-000: Fix i18next-fs-backend and i18next-http-middleware vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
         "hapi-pulse": "3.0.1",
         "http-status-codes": "2.3.0",
         "i18next": "26.0.1",
-        "i18next-fs-backend": "2.6.1",
-        "i18next-http-middleware": "3.9.2",
+        "i18next-fs-backend": "2.6.4",
+        "i18next-http-middleware": "3.9.3",
         "ioredis": "5.10.1",
         "jose": "6.2.2",
         "lodash-es": "4.18.1",
@@ -11725,15 +11725,15 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.1.tgz",
-      "integrity": "sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.4.tgz",
+      "integrity": "sha512-lzbUnowXYd5RFO8flpQhd9khYWNgrzwtxHw1kktJCiTRBaAEiLB2t9EPSXRj8qlC7WcEgFDIsmBUixyludcznw==",
       "license": "MIT"
     },
     "node_modules/i18next-http-middleware": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.9.2.tgz",
-      "integrity": "sha512-vzd0Z89xR1yF2V2USVS2G6oOzNilTXsBkxQ16GFPGJO4whQI/LIreh4p4Qy7HXQlGrWVp83YaekuG36+t9anJA==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.9.3.tgz",
+      "integrity": "sha512-4QNrWiueeo0ry7IhclDdoEPtQsX2AN/O8ybDLIm9vfVWqWF9dt2XM9kCxm8ydeBISjjvjqs4d7lPYWVLA0HqIA==",
       "license": "MIT"
     },
     "node_modules/i18next-resources-for-ts": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "hapi-pulse": "3.0.1",
     "http-status-codes": "2.3.0",
     "i18next": "26.0.1",
-    "i18next-fs-backend": "2.6.1",
-    "i18next-http-middleware": "3.9.2",
+    "i18next-fs-backend": "2.6.4",
+    "i18next-http-middleware": "3.9.3",
     "ioredis": "5.10.1",
     "jose": "6.2.2",
     "lodash-es": "4.18.1",
@@ -147,11 +147,9 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
-    "@hapi/content": "6.0.1",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },
-    "flatted": "3.4.2",
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     }


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Bumps two direct dependencies to patched versions:

- `i18next-fs-backend` 2.6.1 → 2.6.4 — patches GHSA-8847-338w-5hcj (path traversal via unsanitised `lng`/`ns` parameters allowing arbitrary file read and overwrite).
- `i18next-http-middleware` 3.9.2 → 3.9.3 — patches GHSA-5fgg-jcpf-8jjw (prototype pollution and path traversal via user-controlled language and namespace parameters) and GHSA-c3h8-g69v-pjrg (HTTP response splitting and DoS via unsanitised `Content-Language` header). 3.9.4 is available but was published after the current npm `before` cutoff; 3.9.3 is outside the advisory range and is the latest safely installable version.

While here, prunes two overrides that no longer do anything: `@hapi/content` at 6.0.1 and `flatted` at 3.4.2. Both were verified by removing them, resolving the lockfile, and confirming neither `npm audit` nor `snyk test` flagged anything new.

The remaining `uuid <14.0.0` advisory (GHSA-w5hq-g745-h8pq) is out of scope — it is transitive via `exceljs` and the only `npm audit fix --force` path downgrades `exceljs` to 3.4.0 which is a breaking change.