### PR TITLE
PAE-250: Fix uuid vulnerability via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19638,13 +19638,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
-    }
+    },
+    "uuid": "^14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -153,6 +153,6 @@
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     },
-    "uuid": "^14.0.0"
+    "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The `uuid` package below 14.0.0 has a missing buffer bounds check in v3/v5/v6 when `buf` is provided ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), [SNYK-JS-UUID-16133035](https://security.snyk.io/vuln/SNYK-JS-UUID-16133035)). `npm audit` flags it on this repo via `exceljs`; the Dependabot alert here is the same issue.

`exceljs` still ships an older uuid range, so this pins `uuid` to `^14.0.0` via an `overrides` entry in `package.json` rather than downgrading `exceljs`. `exceljs` only uses `uuid.v4()`, which is unchanged in v14.

After the override, `npm audit` and `snyk test` both report zero vulnerable paths, and the Dependabot alert will close.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ