### PR TITLE
PAE-250: Fix postcss vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15544,9 +15544,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     },
+    "postcss": "8.5.10",
     "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Pins `postcss` to 8.5.10 via `overrides` to fix [`GHSA-qx2v-qp2m-jg93`](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — moderate XSS via unescaped `</style>` in CSS stringify output. The vulnerable version is pulled in transitively through the webpack toolchain (`autoprefixer`, `cssnano`, `postcss-loader`) and the vitest toolchain (`vite`).

The existing `uuid: 14.0.0` override was checked for staleness — `npm audit` still flags `exceljs` and `uuid` advisories without it, so it stays.

## Verification

`npm audit` reports `0 vulnerabilities`; `snyk test` reports no vulnerable paths. `npm ls postcss` confirms every consumer resolves to 8.5.10.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ