### PR TITLE
PAE-1339: Pin @types/node to 24.x to match Node engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@types/convict": "6.1.6",
-        "@types/node": "25.5.0",
+        "@types/node": "24.12.2",
         "@types/nunjucks": "3.2.6",
         "@vitest/coverage-v8": "4.1.2",
         "@vitest/eslint-plugin": "1.6.13",
@@ -6293,13 +6293,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/nunjucks": {
@@ -19454,9 +19454,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@types/convict": "6.1.6",
-    "@types/node": "25.5.0",
+    "@types/node": "24.12.2",
     "@types/nunjucks": "3.2.6",
     "@vitest/coverage-v8": "4.1.2",
     "@vitest/eslint-plugin": "1.6.13",


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

`@types/node` was pinned at `25.5.0` while `engines.node` is `>=24.10.0` (running Node 24). Type-checking against a newer Node major than the runtime accepts APIs that don't exist in production — exactly the false negatives `lint:types` is meant to prevent. DefinitelyTyped tracks one major per Node major, so the pin should follow the runtime major.

Re-pins `@types/node` to `24.12.2` (latest 24.x at time of writing). Pre-existing advisory `lint:types` error count is unchanged.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ