### PR TITLE
PAE-1183 Adds logging round loading summary load status

### DIFF
--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -660,6 +660,11 @@ export const summaryLogUploadProgressController = {
 
     const session = request.auth.credentials
 
+    request.logger.info(
+      { organisationId, registrationId, summaryLogId },
+      'Rendering summary log progress page - data load started'
+    )
+
     const {
       accreditationNumber,
       loads,
@@ -673,6 +678,11 @@ export const summaryLogUploadProgressController = {
       registrationId,
       summaryLogId,
       session.idToken
+    )
+
+    request.logger.info(
+      { organisationId, registrationId, summaryLogId },
+      'Rendering summary log progress page - data load completed'
     )
 
     const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}`

--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -661,8 +661,7 @@ export const summaryLogUploadProgressController = {
     const session = request.auth.credentials
 
     request.logger.info(
-      { organisationId, registrationId, summaryLogId },
-      'Rendering summary log progress page - data load started'
+      `Rendering summary log progress page for ${summaryLogId} - status load started`
     )
 
     const {
@@ -681,8 +680,7 @@ export const summaryLogUploadProgressController = {
     )
 
     request.logger.info(
-      { organisationId, registrationId, summaryLogId },
-      'Rendering summary log progress page - data load completed'
+      `Rendering summary log progress page for ${summaryLogId} - status load completed`
     )
 
     const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}`


### PR DESCRIPTION
Ticket: [PAE-1183](https://eaflood.atlassian.net/browse/PAE-1183)
## Description

Adds logging round loading summary load status to help traige long-running requests observed in `test` and `prod` environments

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1183]: https://eaflood.atlassian.net/browse/PAE-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ