### PR TITLE
PAE-1412: extract is-production-environment helper to config

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -5,6 +5,11 @@ import { fileURLToPath } from 'node:url'
 import { getLogFormatType, getLogRedactType } from './utils/log.js'
 import { getSessionCacheEngineType } from './utils/session.js'
 
+/**
+ * @import { Schema, SchemaObj } from 'convict'
+ * @import { RedisConfig } from '#server/common/helpers/redis-client.js'
+ */
+
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const fourHoursMs = 14400000
@@ -333,8 +338,3 @@ export const isReportsEnabled = () => config.get('featureFlags.reports')
 
 export const isProductionEnvironment = () =>
   config.get('cdpEnvironment') === 'prod'
-
-/**
- * @import { Schema, SchemaObj } from 'convict'
- * @import { RedisConfig } from '#server/common/helpers/redis-client.js'
- */

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -331,6 +331,9 @@ config.validate({ allowed: 'strict' })
 
 export const isReportsEnabled = () => config.get('featureFlags.reports')
 
+export const isProductionEnvironment = () =>
+  config.get('cdpEnvironment') === 'prod'
+
 /**
  * @import { Schema, SchemaObj } from 'convict'
  * @import { RedisConfig } from '#server/common/helpers/redis-client.js'

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect } from 'vitest'
-import { config, isReportsEnabled } from './config.js'
+import { config, isProductionEnvironment, isReportsEnabled } from './config.js'
 
 describe(isReportsEnabled, () => {
   afterEach(() => {
@@ -13,5 +13,31 @@ describe(isReportsEnabled, () => {
   it('should return true when flag is enabled', () => {
     config.set('featureFlags.reports', true)
     expect(isReportsEnabled()).toBe(true)
+  })
+})
+
+describe(isProductionEnvironment, () => {
+  afterEach(() => {
+    config.reset('cdpEnvironment')
+  })
+
+  it('should return true when cdpEnvironment is prod', () => {
+    config.set('cdpEnvironment', 'prod')
+
+    expect(isProductionEnvironment()).toBe(true)
+  })
+
+  it.each([
+    'local',
+    'infra-dev',
+    'management',
+    'dev',
+    'test',
+    'perf-test',
+    'ext-test'
+  ])('should return false when cdpEnvironment is %s', (env) => {
+    config.set('cdpEnvironment', env)
+
+    expect(isProductionEnvironment()).toBe(false)
   })
 })

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -3,6 +3,11 @@ import { config, isProductionEnvironment } from '#config/config.js'
 import { getTraceId } from '@defra/hapi-tracing'
 
 /**
+ * @import { Options } from 'hapi-pino'
+ * @import { LoggerOptions } from 'pino'
+ */
+
+/**
  * @typedef {Error & {isBoom: true, output: {statusCode: number, payload: object}, data?: object}} BoomError
  */
 
@@ -82,8 +87,3 @@ export const loggerOptions = {
     return mixinValues
   }
 }
-
-/**
- * @import { Options } from 'hapi-pino'
- * @import { LoggerOptions } from 'pino'
- */

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -1,5 +1,5 @@
 import { ecsFormat } from '@elastic/ecs-pino-format'
-import { config } from '#config/config.js'
+import { config, isProductionEnvironment } from '#config/config.js'
 import { getTraceId } from '@defra/hapi-tracing'
 
 /**
@@ -9,8 +9,6 @@ import { getTraceId } from '@defra/hapi-tracing'
 const logConfig = config.get('log')
 const serviceName = config.get('serviceName')
 const serviceVersion = config.get('serviceVersion')
-const cdpEnvironment = config.get('cdpEnvironment')
-const isProductionEnvironment = cdpEnvironment === 'prod'
 
 /**
  * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
@@ -55,7 +53,7 @@ export const loggerOptions = {
 
       // Include Boom error details for better debugging (non-prod only)
       // @ts-expect-error - check for Boom error before casting
-      if (!isProductionEnvironment && err.isBoom && err.output) {
+      if (!isProductionEnvironment() && err.isBoom && err.output) {
         /** @type {BoomError} */
         const boomErr = /** @type {BoomError} */ (err)
         errorObj.statusCode = boomErr.output.statusCode

--- a/src/server/common/helpers/logging/logger-options.test.js
+++ b/src/server/common/helpers/logging/logger-options.test.js
@@ -1,24 +1,7 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { loggerOptions } from './logger-options.js'
+import { describe, test, expect, afterEach } from 'vitest'
 
-vi.mock(import('#config/config.js'), () => ({
-  config: {
-    get: vi.fn((key) => {
-      const values = {
-        log: {
-          enabled: true,
-          level: 'info',
-          format: 'pino-pretty',
-          redact: []
-        },
-        serviceName: 'test-service',
-        serviceVersion: '1.0.0',
-        cdpEnvironment: 'test'
-      }
-      return values[key]
-    })
-  }
-}))
+import { loggerOptions } from './logger-options.js'
+import { config } from '#config/config.js'
 
 describe('loggerOptions.serializers.err', () => {
   const { err: errorSerializer } = loggerOptions.serializers
@@ -103,33 +86,13 @@ describe('loggerOptions.serializers.err', () => {
 })
 
 describe('loggerOptions in production environment', () => {
-  beforeEach(() => {
-    vi.resetModules()
+  afterEach(() => {
+    config.reset('cdpEnvironment')
   })
 
-  test('excludes Boom error details in prod environment', async () => {
-    vi.doMock(import('#config/config.js'), () => ({
-      config: {
-        get: vi.fn((key) => {
-          const values = {
-            log: {
-              enabled: true,
-              level: 'info',
-              format: 'ecs',
-              redact: []
-            },
-            serviceName: 'test-service',
-            serviceVersion: '1.0.0',
-            cdpEnvironment: 'prod'
-          }
-          return values[key]
-        })
-      }
-    }))
-
-    const { loggerOptions: prodLoggerOptions } =
-      await import('./logger-options.js')
-    const { err: errorSerializer } = prodLoggerOptions.serializers
+  test('excludes Boom error details in prod environment', () => {
+    config.set('cdpEnvironment', 'prod')
+    const { err: errorSerializer } = loggerOptions.serializers
 
     const boomError = new Error('Validation failed')
     boomError.isBoom = true


### PR DESCRIPTION
Ticket: [PAE-1412](https://eaflood.atlassian.net/browse/PAE-1412)
extract `isProductionEnvironment()` to `src/config/config.js` alongside `isReportsEnabled` and replace the inlined const in `logger-options.js`.

[PAE-1412]: https://eaflood.atlassian.net/browse/PAE-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ