### PR TITLE
PAE-1446: prevent double-click on PRN status action buttons

### DIFF
--- a/src/server/prns/action-controller.test.js
+++ b/src/server/prns/action-controller.test.js
@@ -314,7 +314,9 @@ describe('#actionController', () => {
       const { body } = dom.window.document
       const main = getByRole(body, 'main')
 
-      expect(getByRole(main, 'button', { name: /Issue PRN/i })).toBeDefined()
+      const issueButton = getByRole(main, 'button', { name: /Issue PRN/i })
+      expect(issueButton).toBeDefined()
+      expect(issueButton.getAttribute('data-prevent-double-click')).toBe('true')
     })
 
     it('displays Delete PRN button when status is awaiting_authorisation', async ({

--- a/src/server/prns/action.njk
+++ b/src/server/prns/action.njk
@@ -56,7 +56,8 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
-            text: issueButton.text
+            text: issueButton.text,
+            preventDoubleClick: true
           }) }}
 
           {% if deleteButton %}

--- a/src/server/prns/cancel-controller.test.js
+++ b/src/server/prns/cancel-controller.test.js
@@ -168,6 +168,7 @@ describe('#cancelController', () => {
         })
         expect(button).toBeDefined()
         expect(button.classList.contains('govuk-button--warning')).toBe(true)
+        expect(button.getAttribute('data-prevent-double-click')).toBe('true')
       })
 
       it('displays back link to action page', async ({ server }) => {

--- a/src/server/prns/cancel.njk
+++ b/src/server/prns/cancel.njk
@@ -22,7 +22,8 @@
 
       {{ govukButton({
         text: confirmButton,
-        classes: "govuk-button--warning"
+        classes: "govuk-button--warning",
+        preventDoubleClick: true
       }) }}
     </form>
   </div>

--- a/src/server/prns/controller.test.js
+++ b/src/server/prns/controller.test.js
@@ -241,6 +241,26 @@ describe('#createPrnController', () => {
         ).toBeDefined()
       })
 
+      it('should render submit button with double-click prevention', async ({
+        server
+      }) => {
+        const { result } = await server.inject({
+          method: 'GET',
+          url: reprocessorUrl,
+          auth: mockAuth
+        })
+
+        const dom = new JSDOM(result)
+        const { body } = dom.window.document
+        const main = getByRole(body, 'main')
+
+        const submitButton = getByRole(main, 'button', { name: /Continue/i })
+        expect(submitButton).toBeDefined()
+        expect(submitButton.getAttribute('data-prevent-double-click')).toBe(
+          'true'
+        )
+      })
+
       it('should fetch registration data with correct parameters', async ({
         server
       }) => {

--- a/src/server/prns/create.njk
+++ b/src/server/prns/create.njk
@@ -112,7 +112,8 @@
         }) }}
 
         {{ govukButton({
-          text: submitButton.text
+          text: submitButton.text,
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/src/server/prns/delete-controller.test.js
+++ b/src/server/prns/delete-controller.test.js
@@ -149,6 +149,7 @@ describe('#deleteController', () => {
         })
         expect(button).toBeDefined()
         expect(button.classList.contains('govuk-button--warning')).toBe(true)
+        expect(button.getAttribute('data-prevent-double-click')).toBe('true')
       })
 
       it('displays back link to PRN view page', async ({ server }) => {

--- a/src/server/prns/delete.njk
+++ b/src/server/prns/delete.njk
@@ -25,7 +25,8 @@
 
       {{ govukButton({
         text: confirmButton,
-        classes: "govuk-button--warning"
+        classes: "govuk-button--warning",
+        preventDoubleClick: true
       }) }}
     </form>
   </div>

--- a/src/server/prns/discard-controller.test.js
+++ b/src/server/prns/discard-controller.test.js
@@ -221,6 +221,7 @@ describe('#discardController', () => {
         })
         expect(button).toBeDefined()
         expect(button.classList.contains('govuk-button--warning')).toBe(true)
+        expect(button.getAttribute('data-prevent-double-click')).toBe('true')
       })
 
       it('displays back link to check page', async ({ server }) => {

--- a/src/server/prns/discard.njk
+++ b/src/server/prns/discard.njk
@@ -25,7 +25,8 @@
 
       {{ govukButton({
         text: confirmButton,
-        classes: "govuk-button--warning"
+        classes: "govuk-button--warning",
+        preventDoubleClick: true
       }) }}
     </form>
   </div>


### PR DESCRIPTION
Ticket: [PAE-1446](https://eaflood.atlassian.net/browse/PAE-1446)
- Add `preventDoubleClick: true` to Issue, Cancel, Delete, Discard, and Create PRN/PERN submit buttons
- Prevents duplicate form submissions if a user clicks rapidly, complementing any server-side idempotency guard
- Add `data-prevent-double-click` assertions to the five corresponding controller test files

Relates to PAE-1439, PAE-1441

[PAE-1446]: https://eaflood.atlassian.net/browse/PAE-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ