### PR TITLE
PAE-250: Fix @babel/plugin-transform-modules-systemjs and fast-uri vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10595,9 +10595,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -147,9 +147,11 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },
+    "fast-uri": "3.1.2",
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Adds two npm `overrides` to remove three high-severity advisories:

- [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) — `@babel/plugin-transform-modules-systemjs` versions `7.12.0–7.29.0` generate arbitrary code when compiling malicious input. Pulled in transitively via `@babel/preset-env`; pinned to `7.29.4`.
- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — `fast-uri <=3.1.1` is vulnerable to path traversal via percent-encoded dot segments.
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — `fast-uri <=3.1.1` is vulnerable to host confusion via percent-encoded authority delimiters. Pulled in via `ajv` and `schema-utils`; pinned to `3.1.2`.

## Why overrides

In both cases the parent packages still allow the vulnerable ranges, so a semver-compatible override is the safe fix. `npm ls` confirms both pinned versions are taking effect, and `npm audit` now reports 0 vulnerabilities.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ