### PR TITLE
PAE-250: Remove stale @babel/plugin-transform-modules-systemjs and fast-uri overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,11 +147,9 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
-    "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },
-    "fast-uri": "3.1.2",
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Both overrides were originally added to silence transitive vulnerabilities. Their parent packages have since updated their dependency ranges, so neither override changes the resolved tree any more.

Verified by removing each override individually, re-resolving the lockfile, and confirming both `npm audit` and `snyk test` report no new findings.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ