### PR TITLE
PAE-1339: fix type errors

### DIFF
--- a/.github/actions/test-and-scan/action.yml
+++ b/.github/actions/test-and-scan/action.yml
@@ -34,6 +34,10 @@ runs:
       shell: bash
       run: npm run lint
 
+    - name: Lint types
+      shell: bash
+      run: npm run lint:types
+
     - name: Build
       shell: bash
       run: npm run build

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -54,52 +54,6 @@ jobs:
         run: npm run check:i18n
         continue-on-error: true #FIXME: 🚨 Make this a blocking step after translations are available
 
-  type-check:
-    name: Lint Types (advisory)
-    runs-on: ubuntu-latest
-    needs: pr-prep
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      - name: Upgrade npm
-        run: npm install -g npm@11.12.1
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Lint types
-        run: |
-          OUTPUT=$(npm run lint:types 2>&1) && STATUS=0 || STATUS=$?
-          echo "$OUTPUT"
-
-          ERRORS=$(echo "$OUTPUT" | grep -c "^src/" || true)
-
-          {
-            if [ "$STATUS" -eq 0 ]; then
-              echo "## Lint Types"
-              echo ""
-              echo ":white_check_mark: Type check passed"
-            else
-              echo "## Lint Types"
-              echo ""
-              echo ":warning: **${ERRORS} type errors found** (advisory — not blocking)"
-              echo ""
-              echo "<details><summary>Errors by file</summary>"
-              echo ""
-              echo '```'
-              echo "$OUTPUT" | grep "^src/" | sed 's/(.*/:/' | sort | uniq -c | sort -rn
-              echo '```'
-              echo "</details>"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
   test-journey:
     name: Run Journey Tests
     runs-on: ubuntu-latest

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,6 +79,7 @@ export default [
           definedTypes: [
             'BodyInit',
             'HeadersInit',
+            'NodeJS',
             'RequestInfo',
             'RequestInit',
             'Response'

--- a/src/domain/organisations/model.js
+++ b/src/domain/organisations/model.js
@@ -219,7 +219,7 @@ export const USER_ROLES = Object.freeze({
 /**
  * @typedef {{
  *   name: string;
- *   type: Pick<PartnerType, 'company'|'individual'>;
+ *   type: Extract<PartnerType, 'company' | 'individual'>;
  * }} Partner
  */
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import { startServer } from '#server/common/helpers/start-server.js'
 
 await startServer()
 
-process.on('unhandledRejection', (error) => {
+process.on('unhandledRejection', (reason) => {
   const logger = createLogger()
-  logger.error({ message: 'Unhandled rejection', err: error })
+  const err = reason instanceof Error ? reason : new Error(String(reason))
+  logger.error({ message: 'Unhandled rejection', err })
   process.exitCode = 1
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -78,4 +78,27 @@ describe('#index', () => {
       expect(process.exitCode).toBe(1)
     })
   })
+
+  describe('when unhandledRejection occurs with a non-Error reason', () => {
+    beforeEach(async () => {
+      await import('./index.js')
+
+      process.emit('unhandledRejection', 'plain string rejection')
+    })
+
+    test('should wrap the reason in an Error before logging', () => {
+      expect(mockLoggerError).toHaveBeenCalledWith({
+        message: 'Unhandled rejection',
+        err: expect.any(Error)
+      })
+
+      const [{ err }] = mockLoggerError.mock.calls[0]
+
+      expect(err.message).toBe('plain string rejection')
+    })
+
+    test('should set process exitCode to 1', () => {
+      expect(process.exitCode).toBe(1)
+    })
+  })
 })

--- a/src/server/auth/helpers/get-redirect-url.js
+++ b/src/server/auth/helpers/get-redirect-url.js
@@ -1,6 +1,6 @@
 import { config } from '#config/config.js'
 
-/** @import { Request } from '@hapi/hapi' */
+/** @import { HapiRequest } from '#server/common/hapi-types.js' */
 
 const PRODUCTION_SERVICE_URL =
   'https://record-reprocessed-exported-packaging-waste.defra.gov.uk'
@@ -9,7 +9,7 @@ const VALID_PROTOCOLS = new Set(['http', 'https'])
 
 /**
  * Gets a redirect URL from the request, restricted to allowed origins
- * @param {Request} request
+ * @param {HapiRequest} request
  * @param {string} path
  * @returns {string}
  */

--- a/src/server/auth/plugins/defra-id.js
+++ b/src/server/auth/plugins/defra-id.js
@@ -1,3 +1,4 @@
+import { asHapiRequest } from '#server/common/hapi-types.js'
 import { config } from '#config/config.js'
 import { paths } from '#server/paths.js'
 import bell from '@hapi/bell'
@@ -57,7 +58,7 @@ const createDefraId = (verifyToken) => ({
             }
           }
 
-          return getRedirectUrl(request, paths.auth.callback)
+          return getRedirectUrl(asHapiRequest(request), paths.auth.callback)
         },
         password: config.get('session.cookie.password'),
         provider: {

--- a/src/server/common/constants/validation-codes.js
+++ b/src/server/common/constants/validation-codes.js
@@ -93,6 +93,7 @@ const ID_ERROR_CODES = new Set(['MUST_BE_3_DIGIT_NUMBER'])
 
 const ID_HEADERS = new Set(['OSR_ID', 'INTERIM_SITE_ID'])
 
+/** @type {Array<[Set<string>, Set<string>, string]>} */
 const FIELD_RULES = [
   [CALCULATED_ERROR_CODES, CALCULATED_HEADERS, 'CALCULATED_FIELD_MISMATCH'],
   [PERCENTAGE_ERROR_CODES, PERCENTAGE_HEADERS, 'PERCENTAGE_FORMAT_INVALID'],
@@ -183,12 +184,15 @@ const GROUP_DISPLAY_CODES = new Map([
  * @returns {string} Display code for translation lookup
  */
 export const getDisplayCodeFromErrorCode = (errorCode, header) => {
-  const fieldMatch = FIELD_RULES.find(
-    ([errorCodes, headers]) => errorCodes.has(errorCode) && headers.has(header)
-  )
+  if (header) {
+    const fieldMatch = FIELD_RULES.find(
+      ([errorCodes, headers]) =>
+        errorCodes.has(errorCode) && headers.has(header)
+    )
 
-  if (fieldMatch) {
-    return fieldMatch[2]
+    if (fieldMatch) {
+      return fieldMatch[2]
+    }
   }
 
   return GROUP_DISPLAY_CODES.get(errorCode) ?? errorCode

--- a/src/server/common/enums/error-codes.js
+++ b/src/server/common/enums/error-codes.js
@@ -5,6 +5,8 @@
 export const errorCodes = {
   accreditationIdMismatch: 'accreditation_id_mismatch',
   externalFetchFailed: 'external_fetch_failed',
+  glassRecyclingProcessMissing: 'glass_recycling_process_missing',
+  glassRecyclingProcessUnknown: 'glass_recycling_process_unknown',
   invalidPrnField: 'invalid_prn_field',
   notAccredited: 'not_accredited',
   prnCancelFailed: 'prn_cancel_failed',

--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -136,4 +136,13 @@
  * }} HapiServerRegisterPluginObject
  */
 
-export {} // NOSONAR: javascript:S7787 - Required to make this file a module for JSDoc @import
+/**
+ * Cast Hapi's base Request to our augmented HapiRequest. Safe wherever our
+ * plugins have run (route handlers, server.ext callbacks, Bell strategy
+ * callbacks). Goes through `unknown` because TS treats the structural
+ * narrowing of auth/logger as invariant.
+ * @param {Request} request
+ * @returns {HapiRequest}
+ */
+export const asHapiRequest = (request) =>
+  /** @type {HapiRequest} */ (/** @type {unknown} */ (request))

--- a/src/server/common/helpers/content-security-policy.js
+++ b/src/server/common/helpers/content-security-policy.js
@@ -1,13 +1,35 @@
 import Blankie from 'blankie'
 import { config } from '#config/config.js'
 
+/**
+ * @import { ServerRegisterPluginObject } from '@hapi/hapi'
+ */
+
+/**
+ * @typedef {{
+ *   defaultSrc?: string[]
+ *   fontSrc?: string[]
+ *   connectSrc?: string[]
+ *   mediaSrc?: string[]
+ *   styleSrc?: string[]
+ *   scriptSrc?: string[]
+ *   imgSrc?: string[]
+ *   frameSrc?: string[]
+ *   objectSrc?: string[]
+ *   frameAncestors?: string[]
+ *   formAction?: string[]
+ *   manifestSrc?: string[]
+ *   generateNonces?: boolean
+ * }} BlankieOptions
+ */
+
 export function cspFormAction({ isProduction }) {
   return isProduction ? ['self'] : ['self', 'localhost:*']
 }
 
 /**
  * Manage content security policies.
- * @satisfies {import('@hapi/hapi').Plugin}
+ * @satisfies {ServerRegisterPluginObject<BlankieOptions>}
  */
 const contentSecurityPolicy = {
   plugin: Blankie,

--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -37,11 +37,11 @@ function statusCodeMessage(statusCode, localise) {
 }
 
 /**
- * @param { Request } rawRequest
+ * @param { Request } r
  * @param { ResponseToolkit } h
  */
-export async function catchAll(rawRequest, h) {
-  const request = asHapiRequest(rawRequest)
+export async function catchAll(r, h) {
+  const request = asHapiRequest(r)
   const { response } = request
 
   if (!('isBoom' in response)) {

--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -1,5 +1,6 @@
 import { removeUserSession } from '#server/auth/helpers/user-session.js'
 import { statusCodes } from '#server/common/constants/status-codes.js'
+import { asHapiRequest } from '#server/common/hapi-types.js'
 
 const statusCodeErrors = {
   [statusCodes.notFound]: {
@@ -40,9 +41,7 @@ function statusCodeMessage(statusCode, localise) {
  * @param { ResponseToolkit } h
  */
 export async function catchAll(rawRequest, h) {
-  const request = /** @type {HapiRequest} */ (
-    /** @type {unknown} */ (rawRequest)
-  )
+  const request = asHapiRequest(rawRequest)
   const { response } = request
 
   if (!('isBoom' in response)) {
@@ -70,5 +69,4 @@ export async function catchAll(rawRequest, h) {
 
 /**
  * @import { Request, ResponseToolkit } from '@hapi/hapi'
- * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -36,10 +36,13 @@ function statusCodeMessage(statusCode, localise) {
 }
 
 /**
- * @param { HapiRequest } request
+ * @param { Request } rawRequest
  * @param { ResponseToolkit } h
  */
-export async function catchAll(request, h) {
+export async function catchAll(rawRequest, h) {
+  const request = /** @type {HapiRequest} */ (
+    /** @type {unknown} */ (rawRequest)
+  )
   const { response } = request
 
   if (!('isBoom' in response)) {
@@ -66,6 +69,6 @@ export async function catchAll(request, h) {
 }
 
 /**
- * @import { ResponseToolkit } from '@hapi/hapi'
+ * @import { Request, ResponseToolkit } from '@hapi/hapi'
  * @import { HapiRequest } from '#server/common/hapi-types.js'
  */

--- a/src/server/common/helpers/i18n/i18n.js
+++ b/src/server/common/helpers/i18n/i18n.js
@@ -2,7 +2,7 @@ import { languages } from '#server/common/constants/languages.js'
 import fs from 'fs'
 import i18next from 'i18next'
 import Backend from 'i18next-fs-backend'
-import middleware from 'i18next-http-middleware'
+import { LanguageDetector } from 'i18next-http-middleware'
 import path from 'path'
 
 /**
@@ -31,31 +31,30 @@ export async function initI18n() {
   const serverDir = path.resolve('src/server')
   const ns = findNamespaces(serverDir)
 
-  await i18next
-    .use(Backend)
-    .use(middleware.LanguageDetector)
-    .init({
-      lng: languages.ENGLISH,
-      fallbackLng: languages.ENGLISH,
-      preload: [languages.ENGLISH, languages.WELSH],
-      supportedLngs: [languages.ENGLISH, languages.WELSH],
-      ns,
-      defaultNS: 'common',
-      backend: {
-        loadPath: path.resolve('src/server/{{ns}}/{{lng}}.json')
-      },
-      detection: {
-        order: ['path', 'querystring', 'cookie', 'header'],
-        lookupQuerystring: 'lang',
-        lookupCookie: 'i18next',
-        caches: false
-      },
-      interpolation: {
-        escapeValue: false
-      },
-      debug: false,
-      showSupportNotice: false
-    })
+  const initOptions = {
+    lng: languages.ENGLISH,
+    fallbackLng: languages.ENGLISH,
+    preload: [languages.ENGLISH, languages.WELSH],
+    supportedLngs: [languages.ENGLISH, languages.WELSH],
+    ns,
+    defaultNS: 'common',
+    backend: {
+      loadPath: path.resolve('src/server/{{ns}}/{{lng}}.json')
+    },
+    detection: {
+      order: ['path', 'querystring', 'cookie', 'header'],
+      lookupQuerystring: 'lang',
+      lookupCookie: 'i18next',
+      caches: false
+    },
+    interpolation: {
+      escapeValue: false
+    },
+    debug: false,
+    showSupportNotice: false
+  }
+
+  await i18next.use(Backend).use(LanguageDetector).init(initOptions)
 
   return i18next
 }

--- a/src/server/common/helpers/i18n/i18n.test.js
+++ b/src/server/common/helpers/i18n/i18n.test.js
@@ -1,7 +1,7 @@
 import { languages } from '#server/common/constants/languages.js'
 import i18next from 'i18next'
 import Backend from 'i18next-fs-backend'
-import middleware from 'i18next-http-middleware'
+import { LanguageDetector } from 'i18next-http-middleware'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { initI18n } from './i18n.js'
 
@@ -19,7 +19,7 @@ describe(initI18n, function () {
     await initI18n()
 
     expect(i18next.use).toHaveBeenCalledWith(Backend)
-    expect(i18next.use).toHaveBeenCalledWith(middleware.LanguageDetector)
+    expect(i18next.use).toHaveBeenCalledWith(LanguageDetector)
     expect(i18next.init).toHaveBeenCalledWith(
       expect.objectContaining({
         fallbackLng: languages.ENGLISH,

--- a/src/server/common/helpers/i18next.js
+++ b/src/server/common/helpers/i18next.js
@@ -4,7 +4,7 @@ import { localiseUrl } from './i18n/localiseUrl.js'
 
 /**
  * Creates a URL localizer function for the given language
- * @param {string | undefined} locale - The (language code or) locale (e.g., 'en', 'cy', 'en-GB')
+ * @param {string} locale - The (language code or) locale (e.g., 'en', 'cy', 'en-GB')
  * @returns {(path: string) => string} A function to localize URLs
  */
 export const getLocaliseUrl = (locale) => {

--- a/src/server/common/helpers/i18next.js
+++ b/src/server/common/helpers/i18next.js
@@ -1,4 +1,4 @@
-import middleware from 'i18next-http-middleware'
+import { handle } from 'i18next-http-middleware'
 import { languages, pathPrefix } from '../constants/languages.js'
 import { localiseUrl } from './i18n/localiseUrl.js'
 
@@ -18,7 +18,7 @@ export const i18nPlugin = {
   register: async function (server, opt) {
     const { i18next, ...options } = opt
 
-    const i18nMiddleware = middleware.handle(i18next, {
+    const i18nMiddleware = handle(i18next, {
       ...options
     })
 

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -8,7 +8,7 @@ const serviceVersion = config.get('serviceVersion')
 const tracingHeader = config.get('tracing.header')
 
 const ecsOptions = ecsFormat({
-  serviceVersion,
+  serviceVersion: serviceVersion ?? undefined,
   serviceName,
   convertReqRes: true
 })

--- a/src/server/common/helpers/materials/get-display-material.js
+++ b/src/server/common/helpers/materials/get-display-material.js
@@ -1,5 +1,10 @@
 import { errorCodes } from '#server/common/enums/error-codes.js'
+import { MATERIAL } from '#domain/organisations/model.js'
 import { internal } from '#server/common/helpers/logging/cdp-boom.js'
+
+/**
+ * @import { Material, GlassRecyclingProcess } from '#domain/organisations/model.js'
+ */
 
 const MATERIAL_DISPLAY_NAMES = Object.freeze({
   aluminium: 'Aluminium',
@@ -16,33 +21,53 @@ const GLASS_DISPLAY_NAMES = Object.freeze({
 })
 
 /**
- * Gets the display name for a registration's material
- * @param {object} registration - The registration object
- * @param {string} registration.material - The material code
- * @param {string[]} [registration.glassRecyclingProcess] - The glass recycling process array (required for glass)
- * @returns {string} The formatted display name
+ * @template {Record<string, string>} T
+ * @param {T} displayNames
+ * @param {string} key
+ * @param {string} code
+ * @param {string} label
+ * @returns {string}
  */
-export function getDisplayMaterial(registration) {
-  const { material, glassRecyclingProcess } = registration
+const lookupOrThrow = (displayNames, key, code, label) => {
+  const displayName = displayNames[key]
 
-  if (material !== 'glass') {
-    const displayName = MATERIAL_DISPLAY_NAMES[material]
+  if (!displayName) {
+    throw internal(`Unknown ${label}: ${key}`, code, {
+      event: { action: 'lookup_material', reason: `${label}=${key}` }
+    })
+  }
 
-    if (!displayName) {
+  return displayName
+}
+
+/**
+ * Gets the display name for a registration's material.
+ * For glass, uses the first glassRecyclingProcess entry as the lookup key.
+ * @param {{material: Material, glassRecyclingProcess?: GlassRecyclingProcess[]}} registration
+ * @returns {string}
+ */
+export const getDisplayMaterial = ({ material, glassRecyclingProcess }) => {
+  if (material === MATERIAL.GLASS) {
+    if (!glassRecyclingProcess || glassRecyclingProcess.length === 0) {
       throw internal(
-        `Unknown material: ${material}`,
-        errorCodes.unknownMaterial,
-        {
-          event: {
-            action: 'lookup_material',
-            reason: `material=${material}`
-          }
-        }
+        'Missing glassRecyclingProcess for glass material',
+        errorCodes.glassRecyclingProcessMissing,
+        { event: { action: 'lookup_material', reason: 'material=glass' } }
       )
     }
 
-    return displayName
+    return lookupOrThrow(
+      GLASS_DISPLAY_NAMES,
+      glassRecyclingProcess[0],
+      errorCodes.glassRecyclingProcessUnknown,
+      'glassRecyclingProcess'
+    )
   }
 
-  return GLASS_DISPLAY_NAMES[glassRecyclingProcess[0]]
+  return lookupOrThrow(
+    MATERIAL_DISPLAY_NAMES,
+    material,
+    errorCodes.unknownMaterial,
+    'material'
+  )
 }

--- a/src/server/common/helpers/materials/get-display-material.test.js
+++ b/src/server/common/helpers/materials/get-display-material.test.js
@@ -34,15 +34,41 @@ describe(getDisplayMaterial, () => {
     })
   })
 
-  describe('unknown material', () => {
-    it('should throw for unknown material', () => {
-      const registration = { material: 'unknown' }
-
+  describe('invalid registrations', () => {
+    it.each([
+      [
+        'material is unknown',
+        { material: 'unknown' },
+        {
+          message: 'Unknown material: unknown',
+          code: 'unknown_material',
+          event: { action: 'lookup_material', reason: 'material=unknown' }
+        }
+      ],
+      [
+        'glassRecyclingProcess is missing',
+        { material: 'glass' },
+        {
+          message: 'Missing glassRecyclingProcess for glass material',
+          code: 'glass_recycling_process_missing',
+          event: { action: 'lookup_material', reason: 'material=glass' }
+        }
+      ],
+      [
+        'glassRecyclingProcess value is unknown',
+        { material: 'glass', glassRecyclingProcess: ['glass_invalid'] },
+        {
+          message: 'Unknown glassRecyclingProcess: glass_invalid',
+          code: 'glass_recycling_process_unknown',
+          event: {
+            action: 'lookup_material',
+            reason: 'glassRecyclingProcess=glass_invalid'
+          }
+        }
+      ]
+    ])('should throw when %s', (_label, registration, expected) => {
       expect(() => getDisplayMaterial(registration)).toThrow(
-        expect.objectContaining({
-          isBoom: true,
-          message: 'Unknown material: unknown'
-        })
+        expect.objectContaining({ isBoom: true, ...expected })
       )
     })
   })

--- a/src/server/common/helpers/secure-context/get-trust-store-certs.js
+++ b/src/server/common/helpers/secure-context/get-trust-store-certs.js
@@ -1,6 +1,6 @@
 /**
  * Get base64 certs from all environment variables starting with TRUSTSTORE_
- * @param {import('node:process').ProcessEnv} envs
+ * @param {NodeJS.ProcessEnv} envs
  * @returns {string[]}
  */
 export function getTrustStoreCerts(envs) {

--- a/src/server/common/helpers/upload/fetch-summary-log-status.js
+++ b/src/server/common/helpers/upload/fetch-summary-log-status.js
@@ -10,7 +10,7 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
  * @param {string} organisationId
  * @param {string} registrationId
  * @param {string} summaryLogId
- * @param {object} [options]
+ * @param {object} options
  * @param {string} options.idToken - JWT ID token for authorization
  * @returns {Promise<SummaryLogStatusResponse>}
  */
@@ -18,7 +18,7 @@ const fetchSummaryLogStatus = async (
   organisationId,
   registrationId,
   summaryLogId,
-  { idToken } = {}
+  { idToken }
 ) => {
   const data = await fetchJsonFromBackend(
     `/v1/organisations/${organisationId}/registrations/${registrationId}/summary-logs/${summaryLogId}`,

--- a/src/server/common/helpers/waste-organisations/api-adapter.js
+++ b/src/server/common/helpers/waste-organisations/api-adapter.js
@@ -1,19 +1,31 @@
-/** @import {WasteOrganisationsService} from './port.js' */
-
 import { getYear } from 'date-fns'
 
 import { config } from '#config/config.js'
 import { loggingEventActions } from '#server/common/enums/event.js'
 import { fetchJson } from '../fetch-json.js'
 
+/**
+ * @import {TypedLogger} from '#server/common/helpers/logging/logger.js'
+ * @import {WasteOrganisationsService} from './port.js'
+ * @import {WasteOrganisation, WasteOrganisationType} from './types.js'
+ */
+
+/**
+ * Raw upstream shape before registrationType extraction — has the wider
+ * registrations array that we collapse into a single registrationType.
+ * @typedef {Omit<WasteOrganisation, 'registrationType'> & {
+ *   registrations?: Array<{ type: WasteOrganisationType, registrationYear: number | string }>
+ * }} RawWasteOrganisation
+ */
+
 const PRODUCER_TYPES = new Set(['LARGE_PRODUCER', 'COMPLIANCE_SCHEME'])
 
 /**
  * Extracts registrationType from the raw registrations array and warns
  * on missing or ambiguous producer registrations.
- * @param {Array<{ id: string, name: string, registrations?: Array<{ type: string, registrationYear: number | string }>, [key: string]: unknown }>} organisations
- * @param {import('#server/common/helpers/logging/logger.js').TypedLogger} logger
- * @returns {Array<{ registrationType?: string, [key: string]: unknown }>}
+ * @param {RawWasteOrganisation[]} organisations
+ * @param {TypedLogger} logger
+ * @returns {WasteOrganisation[]}
  */
 function extractRegistrationTypes(organisations, logger) {
   // TODO: should this use the accreditation year instead of current year?
@@ -57,7 +69,7 @@ function extractRegistrationTypes(organisations, logger) {
 
 /**
  * Creates a waste organisations service that fetches from the real API.
- * @param {import('#server/common/helpers/logging/logger.js').TypedLogger} logger
+ * @param {TypedLogger} logger
  * @returns {WasteOrganisationsService}
  */
 export function createApiWasteOrganisationsService(logger) {

--- a/src/server/common/helpers/waste-organisations/api-adapter.js
+++ b/src/server/common/helpers/waste-organisations/api-adapter.js
@@ -74,7 +74,7 @@ export function createApiWasteOrganisationsService(logger) {
 
       const params = new URLSearchParams({
         registrations: ['LARGE_PRODUCER', 'COMPLIANCE_SCHEME'],
-        registrationYears: [thisYear],
+        registrationYears: [String(thisYear)],
         statuses: ['REGISTERED']
       })
 

--- a/src/server/common/helpers/waste-organisations/fixtures/in-memory.json
+++ b/src/server/common/helpers/waste-organisations/fixtures/in-memory.json
@@ -14,13 +14,7 @@
         "postcode": "CB21 5LD",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "fcdee15c-6f14-41e8-9f4c-ce1288a72b8e",
@@ -36,13 +30,7 @@
         "postcode": "SE15 3EG",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "2a477323-6c7b-46c5-b141-3bf34ac5e030",
@@ -58,13 +46,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "7115ae56-9775-4578-bbd5-6e1ec41d892f",
@@ -80,13 +62,7 @@
         "postcode": "UB3 2QD",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "c4622525-9f73-4036-baf7-140fd151841e",
@@ -102,13 +78,7 @@
         "postcode": "N22 8JD",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "6ba78514-6f1e-40fb-99d2-54dbd0b392f4",
@@ -124,13 +94,7 @@
         "postcode": "OL7 0PZ",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "6dc555e6-1113-448a-a34d-660f4a1e6dcc",
@@ -146,13 +110,7 @@
         "postcode": "IP28 7DE",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "17d77872-b61b-463b-824a-12eaa4cf1d20",
@@ -168,13 +126,7 @@
         "postcode": "CV1 2BY",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "e6450e61-6d72-42ee-a493-18a1c9b8e7b4",
@@ -190,13 +142,7 @@
         "postcode": "BL3 2PS",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "03971e82-5233-4b95-900b-25bfdeaed9ab",
@@ -212,13 +158,7 @@
         "postcode": "N1 7GU",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "f8a2d00a-615d-494e-8285-58f0c3dd46fb",
@@ -234,13 +174,7 @@
         "postcode": "W1W 5PF",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "0becf127-3eae-4fd0-adb4-7adeccb459d9",
@@ -256,13 +190,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "12a83932-3940-4053-8751-69048a6b118c",
@@ -278,13 +206,7 @@
         "postcode": "S2 2EH",
         "country": "England"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "14c119a1-3bce-42ab-ae89-0c32bfb6dbde",
@@ -300,13 +222,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "8075b75e-ea60-44b3-822f-2c822671ee03",
@@ -322,13 +238,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "a28954f7-31dc-4770-91a6-ddb468dce306",
@@ -344,13 +254,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "f2c22c91-d356-418f-b405-5297304b54ad",
@@ -366,13 +270,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "16649f0b-bbc7-4ccb-a67f-aa849180e9a2",
@@ -388,13 +286,7 @@
         "postcode": "T1 1TT",
         "country": "United Kingdom"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "COMPLIANCE_SCHEME",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "COMPLIANCE_SCHEME"
     },
     {
       "id": "1cb3407b-2ccc-42e3-8813-a28301980f5c",
@@ -410,13 +302,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "bbcdfbeb-810d-4dc8-bbf7-3c9735046942",
@@ -432,13 +318,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "252f5876-3ff3-4e44-8457-95854908a376",
@@ -454,13 +334,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "8a7442b2-f48e-457b-aeac-e294cd290f2e",
@@ -476,13 +350,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "a8c9b5d8-4682-4c95-95a1-dbdabfa30c5e",
@@ -498,13 +366,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "b26657e6-c134-4bdd-a0dc-df2defc7dabb",
@@ -520,13 +382,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "df012b42-09fd-4071-b796-715d76606f49",
@@ -542,13 +398,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "777ac30d-e0ab-446f-ace5-4bc70ec051fa",
@@ -564,13 +414,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "40099dde-2856-4e9e-aed2-b68301b29403",
@@ -586,13 +430,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "94cf3ba1-10b9-4e06-8e9f-412de0d4662b",
@@ -608,13 +446,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "c0253b15-896e-4a0d-a505-46fc10fa839f",
@@ -630,13 +462,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "b21bdcc7-3383-4988-a966-b382d788840e",
@@ -652,13 +478,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "4fb2d105-920a-4b9d-a6fb-a5323845f99a",
@@ -674,18 +494,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2025
-        },
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "752c5b71-3119-45b3-8166-b560222ac679",
@@ -701,13 +510,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "014411a3-bc84-4de0-87f5-7b4a961a07da",
@@ -723,13 +526,7 @@
         "postcode": "Essex",
         "country": "CB113DG"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "b79ec09f-6194-484b-a01f-9ffcb4cf17b9",
@@ -745,13 +542,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "01fc15ed-a5e3-4928-a49a-2a2d72e87a41",
@@ -767,13 +558,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "ae902a5f-a443-41d8-91d0-3dd91136b7c5",
@@ -789,13 +574,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "5c80ca58-d3c9-4761-b2e1-fc7ed8c01aac",
@@ -811,13 +590,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "2bb7ab96-8bac-4dfb-967b-21844ddb6ab6",
@@ -833,18 +606,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2025
-        },
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "b769d2fb-21b4-49d3-83b6-38217bb16d25",
@@ -860,13 +622,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "82502a50-72c3-47ec-8da6-b1a59deb55bf",
@@ -882,13 +638,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "2e5ea32a-116b-40f6-97a8-db44273b6d90",
@@ -904,13 +654,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "f73fff19-ea13-4f05-af45-b35aba62f849",
@@ -926,13 +670,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "affb3e5e-8bea-44a4-a855-cf4ac16a031e",
@@ -948,13 +686,7 @@
         "postcode": "Essex",
         "country": "CB113DG"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "c70c300b-2c90-477e-b3b6-76f73fec54cf",
@@ -970,13 +702,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "5d4c194b-6e90-4bf9-935b-ae8c76005312",
@@ -992,13 +718,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "e79e89b5-cb99-46b5-ac64-1d40a79fa71e",
@@ -1014,13 +734,7 @@
         "postcode": "TT1 1TT",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "5512f242-1492-40f7-93df-3123d040fd52",
@@ -1036,13 +750,7 @@
         "postcode": "CB113DG",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "a5537222-2fa8-44a6-ad4e-628a1e33d97e",
@@ -1058,13 +766,7 @@
         "postcode": "AL7 1GA",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "15ba1cb0-ff4a-4470-994f-3599b0bc4072",
@@ -1080,13 +782,7 @@
         "postcode": "CB113DG",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     },
     {
       "id": "92462140-4bff-4028-a283-3beec633ee76",
@@ -1102,13 +798,7 @@
         "postcode": "CB113DG",
         "country": "EN"
       },
-      "registrations": [
-        {
-          "status": "REGISTERED",
-          "type": "LARGE_PRODUCER",
-          "registrationYear": 2026
-        }
-      ]
+      "registrationType": "LARGE_PRODUCER"
     }
   ]
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -97,7 +97,8 @@ export async function createServer(options = {}) {
     contentSecurityPolicy,
     createWasteOrganisationsPlugin({
       initialOrganisations:
-        options.wasteOrganisations ?? wasteOrganisationsFixture.organisations
+        options.wasteOrganisations ??
+        /** @type {WasteOrganisation[]} */ (wasteOrganisationsFixture.organisations)
     }),
     {
       plugin: i18nPlugin,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -64,7 +64,7 @@ export async function createServer(options = {}) {
       {
         name: config.get('session.cache.name'),
         engine: getCacheEngine(
-          /** @type {Engine} */ config.get('session.cache.engine')
+          /** @type {Engine} */ (config.get('session.cache.engine'))
         )
       }
     ],

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -32,6 +32,7 @@ import { router } from './router.js'
 export async function createServer(options = {}) {
   setupProxy()
 
+  /** @satisfies {RouteOptions} */
   const routes = {
     validate: {
       options: {
@@ -51,7 +52,7 @@ export async function createServer(options = {}) {
       noSniff: true,
       xframe: true
     },
-    auth: { mode: 'required' }
+    auth: { mode: /** @type {const} */ ('required') }
   }
 
   const server = hapi.server({
@@ -144,6 +145,7 @@ export async function createServer(options = {}) {
 }
 
 /**
+ * @import {RouteOptions} from '@hapi/hapi'
  * @import {Engine} from '#server/common/helpers/session-cache/cache-engine.js'
  * @import {WasteOrganisation} from '#server/common/helpers/waste-organisations/types.js'
  */

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -98,7 +98,9 @@ export async function createServer(options = {}) {
     createWasteOrganisationsPlugin({
       initialOrganisations:
         options.wasteOrganisations ??
-        /** @type {WasteOrganisation[]} */ (wasteOrganisationsFixture.organisations)
+        /** @type {WasteOrganisation[]} */ (
+          wasteOrganisationsFixture.organisations
+        )
     }),
     {
       plugin: i18nPlugin,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -55,24 +55,26 @@ export async function createServer(options = {}) {
     auth: { mode: /** @type {const} */ ('required') }
   }
 
-  const server = hapi.server({
-    port: config.get('port'),
-    routes,
-    router: {
-      stripTrailingSlash: true
-    },
-    cache: [
-      {
-        name: config.get('session.cache.name'),
-        engine: getCacheEngine(
-          /** @type {Engine} */ (config.get('session.cache.engine'))
-        )
+  const server = /** @type {HapiServer} */ (
+    hapi.server({
+      port: config.get('port'),
+      routes,
+      router: {
+        stripTrailingSlash: true
+      },
+      cache: [
+        {
+          name: config.get('session.cache.name'),
+          engine: getCacheEngine(
+            /** @type {Engine} */ (config.get('session.cache.engine'))
+          )
+        }
+      ],
+      state: {
+        strictHeader: false
       }
-    ],
-    state: {
-      strictHeader: false
-    }
-  })
+    })
+  )
 
   server.app.cache = server.cache({
     cache: config.get('session.cache.name'),
@@ -147,6 +149,7 @@ export async function createServer(options = {}) {
 /**
  * @import {RouteOptions} from '@hapi/hapi'
  * @import {Engine} from '#server/common/helpers/session-cache/cache-engine.js'
+ * @import {HapiServer} from '#server/common/hapi-types.js'
  * @import {WasteOrganisation} from '#server/common/helpers/waste-organisations/types.js'
  */
 

--- a/src/server/plugins/boom-error-logger.js
+++ b/src/server/plugins/boom-error-logger.js
@@ -21,11 +21,11 @@ export const boomErrorLogger = {
       server.ext(
         'onPreResponse',
         /**
-         * @param {Request} rawRequest
+         * @param {Request} r
          * @param {ResponseToolkit} h
          */
-        (rawRequest, h) => {
-          const request = asHapiRequest(rawRequest)
+        (r, h) => {
+          const request = asHapiRequest(r)
           const response = request.response
 
           if (!('isBoom' in response) || !response.isBoom) {

--- a/src/server/plugins/boom-error-logger.js
+++ b/src/server/plugins/boom-error-logger.js
@@ -3,10 +3,10 @@ import {
   loggingEventActions,
   loggingEventCategories
 } from '#server/common/enums/event.js'
+import { asHapiRequest } from '#server/common/hapi-types.js'
 
 /**
- * @import { ResponseToolkit, Server } from '@hapi/hapi'
- * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { Request, ResponseToolkit, Server } from '@hapi/hapi'
  * @import { CdpBoom } from '#server/common/helpers/logging/cdp-boom.js'
  */
 
@@ -21,10 +21,11 @@ export const boomErrorLogger = {
       server.ext(
         'onPreResponse',
         /**
-         * @param {HapiRequest} request
+         * @param {Request} rawRequest
          * @param {ResponseToolkit} h
          */
-        (request, h) => {
+        (rawRequest, h) => {
+          const request = asHapiRequest(rawRequest)
           const response = request.response
 
           if (!('isBoom' in response) || !response.isBoom) {

--- a/src/server/prns/view-data.js
+++ b/src/server/prns/view-data.js
@@ -9,7 +9,7 @@ import { getDisplayMaterial } from '#server/common/helpers/materials/get-display
  * @param {object} options
  * @param {string} options.organisationId
  * @param {string} options.registrationId
- * @param {{wasteProcessingType: string, material: string, nation?: string, glassRecyclingProcess?: string[]}} options.registration
+ * @param {{wasteProcessingType: string, material: Material, nation?: string, glassRecyclingProcess?: GlassRecyclingProcess[]}} options.registration
  * @param {Array<{value: string, text: string}>} options.recipients
  * @param {{availableAmount: number} | null} [options.wasteBalance]
  * @returns {object}
@@ -74,4 +74,5 @@ export function buildCreatePrnViewData(
 
 /**
  * @import { HapiRequest } from '#server/common/hapi-types.js'
+ * @import { Material, GlassRecyclingProcess } from '#domain/organisations/model.js'
  */


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
clears all 23 source-side type errors reported by `lint:types` on main.

- typed cross-file singletons (unhandled-rejection wrap, csp `Plugin<>` generics, null→undefined coercion for ecsFormat, `NodeJS.ProcessEnv`, required `idToken` arg, locale narrowing)
- guarded `get-display-material` with symmetric unknown-glass-process throw + a typed lookup helper, using domain `MATERIAL`/`GlassRecyclingProcess` enums
- new typed `extractRegistrationTypes` for the waste-organisations api adapter using `Omit<WasteOrganisation, 'registrationType'>`
- i18next-http-middleware switched to named imports; init options lifted out of the literal so `showSupportNotice` passes structural assignment
- `FIELD_RULES` tuple annotation in validation-codes; header narrowed before set lookup
- `Extract` not `Pick` for the partner-type union
- big in-memory waste-organisations fixture transformed once to match `WasteOrganisation[]` (it was raw API shape before, silently breaking in-memory dev mode)
- five hapi typing fixes in `server/index.js` (`RouteOptions` satisfies, auth-mode literal, view-engine cast parens, server cast to `HapiServer`, fixture cast)
- new `asHapiRequest` helper to centralise the unsafe-but-necessary `Request -> HapiRequest` cast at server.ext / bell location / catchAll boundaries
- one eslint config tweak so `NodeJS.*` resolves in `jsdoc/no-undefined-types`

follow-up beads raised:
- glassRecyclingProcess multi-element semantics
- mirror BE VALIDATION_CODE enum in FE (surfaced `MUST_BE_3_DIGIT_NUMBER` vs BE's `MUST_BE_3_DIGIT_ID`)

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ