### PR TITLE
PAE-1450: Add double-click prevention to PRN create button

### DIFF
--- a/src/server/prns/view-controller.test.js
+++ b/src/server/prns/view-controller.test.js
@@ -1124,6 +1124,9 @@ describe('#viewController', () => {
         const createButton = main.querySelector('button.govuk-button')
         expect(createButton).toBeDefined()
         expect(createButton.textContent).toContain('Create PRN')
+        expect(createButton.getAttribute('data-prevent-double-click')).toBe(
+          'true'
+        )
         // Should show check page heading
         expect(getByText(main, /Check before creating PRN/i)).toBeDefined()
         // Should show December waste as Yes
@@ -1472,6 +1475,9 @@ describe('#viewController', () => {
         const createButton = main.querySelector('button.govuk-button')
         expect(createButton).toBeDefined()
         expect(createButton.textContent).toContain('Create PERN')
+        expect(createButton.getAttribute('data-prevent-double-click')).toBe(
+          'true'
+        )
         expect(getByText(main, /Check before creating PERN/i)).toBeDefined()
       })
     })

--- a/src/server/prns/view-controller.test.js
+++ b/src/server/prns/view-controller.test.js
@@ -1122,7 +1122,6 @@ describe('#viewController', () => {
 
         // Should show create button (draft flow)
         const createButton = main.querySelector('button.govuk-button')
-        expect(createButton).toBeDefined()
         expect(createButton.textContent).toContain('Create PRN')
         expect(createButton.getAttribute('data-prevent-double-click')).toBe(
           'true'

--- a/src/server/prns/view.njk
+++ b/src/server/prns/view.njk
@@ -69,7 +69,8 @@
         <input type="hidden" name="crumb" value="{{ crumb }}" />
 
         {{ govukButton({
-          text: createButton.text
+          text: createButton.text,
+          preventDoubleClick: true
         }) }}
       </form>
 


### PR DESCRIPTION
Ticket: [PAE-1450](https://eaflood.atlassian.net/browse/PAE-1450)
## Summary

The `createButton` in the "Check before creating PRN" page (`view.njk`) was missing `preventDoubleClick: true` in its `govukButton` macro call. This button submits a form that creates the PRN and debits the waste balance, so a double-click could cause duplicate submissions.

This adds `preventDoubleClick: true` to the button (rendering `data-prevent-double-click="true"` on the element), consistent with the pattern already applied to other PRN action buttons (issue, cancel, delete, discard) in PAE-1446.

Unit test assertions confirm the attribute is present for both PRN and PERN variants.

[PAE-1450]: https://eaflood.atlassian.net/browse/PAE-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ