### PR TITLE
PAE-1464: Add double-click prevention to reports and account form buttons

### DIFF
--- a/src/server/account/linking/controller.test.js
+++ b/src/server/account/linking/controller.test.js
@@ -170,6 +170,9 @@ describe('#accountLinkingController', () => {
         const submitButton = getByRole(main, 'button', { name: /Confirm/i })
 
         expect(submitButton).toBeDefined()
+        expect(submitButton.getAttribute('data-prevent-double-click')).toBe(
+          'true'
+        )
       })
 
       it('should render radio button for each organisation sorted alphabetically', async ({

--- a/src/server/account/linking/index.njk
+++ b/src/server/account/linking/index.njk
@@ -45,7 +45,8 @@
           }) }}
 
           {{ govukButton({
-            text: localise('account:linking:confirmButton')
+            text: localise('account:linking:confirmButton'),
+            preventDoubleClick: true
           }) }}
 
           {% set unlinkedOrgsList %}

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -844,6 +844,7 @@ describe('#checkController', () => {
 
           expect(button).not.toBeNull()
           expect(button?.textContent?.trim()).toContain('Create report')
+          expect(button?.getAttribute('data-prevent-double-click')).toBe('true')
         })
 
         it('should include report version as hidden form field', async ({

--- a/src/server/reports/check-your-answers.njk
+++ b/src/server/reports/check-your-answers.njk
@@ -260,7 +260,8 @@
         <input type="hidden" name="version" value="{{ version }}" />
 
         {{ govukButton({
-          text: createButtonText
+          text: createButtonText,
+          preventDoubleClick: true
         }) }}
 
         <p class="govuk-body">

--- a/src/server/reports/confirm-delete.njk
+++ b/src/server/reports/confirm-delete.njk
@@ -23,7 +23,8 @@
 
         {{ govukButton({
           text: confirmButtonText,
-          classes: "govuk-button--warning"
+          classes: "govuk-button--warning",
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/src/server/reports/delete-controller.test.js
+++ b/src/server/reports/delete-controller.test.js
@@ -105,6 +105,7 @@ describe('#deleteController', () => {
 
         expect(button).not.toBeNull()
         expect(button?.textContent?.trim()).toContain('Confirm deletion')
+        expect(button?.getAttribute('data-prevent-double-click')).toBe('true')
       })
 
       describe('back link', () => {

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -784,6 +784,7 @@ describe('#detailReportsController', () => {
         })
 
         expect(button).toBeDefined()
+        expect(button.getAttribute('data-prevent-double-click')).toBe('true')
       })
 
       it('should not display ORS help text', async ({ server }) => {

--- a/src/server/reports/detail.njk
+++ b/src/server/reports/detail.njk
@@ -160,7 +160,8 @@
       <form method="POST" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}" />
         {{ govukButton({
-          text: localise("reports:useThisData")
+          text: localise("reports:useThisData"),
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -750,6 +750,7 @@ describe('#submitController', () => {
 
           expect(button).not.toBeNull()
           expect(button.textContent.trim()).toContain('Confirm and submit')
+          expect(button.getAttribute('data-prevent-double-click')).toBe('true')
         })
 
         it('should include report version as hidden form field', async ({

--- a/src/server/reports/submit.njk
+++ b/src/server/reports/submit.njk
@@ -225,7 +225,8 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
-            text: localise("reports:submitButton")
+            text: localise("reports:submitButton"),
+            preventDoubleClick: true
           }) }}
 
           {{ govukButton({


### PR DESCRIPTION
Ticket: [PAE-1464](https://eaflood.atlassian.net/browse/PAE-1464)
## Summary

Several form-submit buttons in the reports and account-linking areas were missing `preventDoubleClick: true` in their `govukButton` macro calls. These buttons trigger data mutations (submitting reports, deleting reports, creating reports, linking accounts) and could be submitted twice by a rapid double-click.

This adds `preventDoubleClick: true` (rendering `data-prevent-double-click="true"` on the element) to five buttons, consistent with the PRN action buttons already protected in PAE-1446 and PAE-1450:

- **reports/submit.njk** — Confirm and submit button
- **reports/check-your-answers.njk** — Create report button
- **reports/confirm-delete.njk** — Confirm deletion button
- **reports/detail.njk** — "Use this data" button
- **account/linking/index.njk** — Confirm account link button

Unit test assertions added for each button.

Note: the delete-report link button in `submit.njk` was not changed because it uses `href` (renders as `<a>`, not `<button>`), so `preventDoubleClick` has no effect.

[PAE-1464]: https://eaflood.atlassian.net/browse/PAE-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ