### PR TITLE
PAE-1479: Update PRN/PERN revenue label to clarify reporting intent

### DIFF
--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -91,7 +91,7 @@
   "noteSummaryHeading": "{{noteTypePlural}} issued for {{material}} packaging waste in {{periodShort}}",
   "noteSummaryPageTitle": "{{noteTypePlural}} issued: {{material}}: {{periodLabel}}",
   "noteSummaryRevenueHint": "Total revenue should be in pounds and pence",
-  "noteSummaryRevenueLabel": "Enter total revenue of {{noteTypePlural}}, excluding VAT",
+  "noteSummaryRevenueLabel": "Enter the total revenue that you have received or expect to receive for these {{noteTypePlural}}, excluding VAT",
   "noteSummarySave": "Save and come back later",
   "noteTypeSectionHeading": "{{noteTypePlural}}",
   "orsHelpLine1": "If any of your ORS data is missing, upload your summary logs again for this period to fix the problem.",

--- a/src/server/reports/helpers/create-prn-summary-controllers.test.js
+++ b/src/server/reports/helpers/create-prn-summary-controllers.test.js
@@ -209,7 +209,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
           const { body } = new JSDOM(result).window.document
           const input = getByRole(body, 'textbox', {
             name: new RegExp(
-              `Enter total revenue of ${subtree.notePlural}, excluding VAT`
+              `Enter the total revenue that you have received or expect to receive for these ${subtree.notePlural}, excluding VAT`
             )
           })
 


### PR DESCRIPTION
Ticket: [PAE-1479](https://eaflood.atlassian.net/browse/PAE-1479)
## Changes

<img width="828" height="584" alt="image" src="https://github.com/user-attachments/assets/6d2883f8-7fa2-4c76-9e1f-747f6b742f21" />


- Update `noteSummaryRevenueLabel` in `en.json` to read: "Enter the total revenue that you have received or expect to receive for these {{noteTypePlural}}, excluding VAT"


[PAE-1479]: https://eaflood.atlassian.net/browse/PAE-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ