### PR TITLE
PAE-250: Fix @hapi/wreck, @hapi/content, tmp and uuid vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,8 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
-ignore: {}
+ignore:
+  'SNYK-JS-POSTCSSSELECTORPARSER-16873882':
+    - '*':
+        reason: 'No upstream fix available. postcss-selector-parser is pulled in transitively by cssnano during the webpack CSS build only and is never reached at application runtime, so the uncontrolled-recursion DoS is not exploitable here. Revisit when a patched version is published.'
+        expires: '2026-11-27T00:00:00.000Z'
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@hapi/inert": "7.1.0",
         "@hapi/scooter": "8.0.0",
         "@hapi/vision": "7.0.3",
-        "@hapi/wreck": "18.1.0",
+        "@hapi/wreck": "18.1.1",
         "@hapi/yar": "11.0.3",
         "accessible-autocomplete": "3.0.1",
         "aws-embedded-metrics": "4.2.1",
@@ -2646,9 +2646,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
-      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -2985,9 +2985,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.1.tgz",
+      "integrity": "sha512-UwTeGBfAnB/1mkw4gD6IQGI/bgMu7iGmqgT8K+xxye3z4ZHhCZlmS2wuHBJmENhBJSKqvoYzJ71ds3Xfq4gofQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -10443,17 +10443,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/exceljs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/execa": {
@@ -19085,9 +19074,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19647,6 +19636,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@hapi/inert": "7.1.0",
     "@hapi/scooter": "8.0.0",
     "@hapi/vision": "7.0.3",
-    "@hapi/wreck": "18.1.0",
+    "@hapi/wreck": "18.1.1",
     "@hapi/yar": "11.0.3",
     "accessible-autocomplete": "3.0.1",
     "aws-embedded-metrics": "4.2.1",
@@ -149,11 +149,14 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
+    "@hapi/content": "6.0.2",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
-    }
+    },
+    "tmp": "0.2.6",
+    "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What changed

Updates three vulnerable dependencies to patched versions and documents one advisory with no upstream fix.

- `@hapi/wreck` → 18.1.1 (direct dependency) — fixes a leak of the `Proxy-Authorization` header to a different host on a cross-hostname redirect (moderate, GHSA-vhjm-w67q-g75c).
- `@hapi/content` → 6.0.2 (override) — fixes a header-parser parameter-smuggling issue where duplicate parameters could bypass upload filters (high, GHSA-36hh-x5p5-jgc8). Reaches us transitively through `@hapi/hapi` → `@hapi/subtext`.
- `tmp` → 0.2.6 (override) — fixes a path traversal where an unsanitised prefix/postfix could escape the intended temp directory (high, GHSA-ph9p-34f9-6g65). Reaches us through `exceljs`.
- `uuid` → 14.0.0 (override) — clears a missing buffer-bounds check in uuid's v3/v5/v6 builders (moderate, GHSA-w5hq-g745-h8pq). Reaches us through `exceljs`, which calls only `v4()` (the affected builders are never used here), but the override removes the flagged version entirely. `exceljs` imports uuid via its named `v4` export, which is unchanged across these versions.

## postcss-selector-parser (no upstream fix)

Snyk flags an uncontrolled-recursion DoS in `postcss-selector-parser` 7.1.1 (moderate, SNYK-JS-POSTCSSSELECTORPARSER-16873882) for which no patched version exists. It is pulled in transitively by `cssnano` during the webpack CSS build and is never reached at application runtime, so the issue is not exploitable here. It is recorded in `.snyk` with a six-month expiry so it resurfaces for review once a fix is available.

## Note on `tmp` 0.2.6

This repo's `.npmrc` sets `min-release-age=7`, a quarantine that keeps freshly published packages out of dependency resolution for seven days. `tmp` 0.2.6 is the only release that fixes the path-traversal advisory and it is newer than that window, so it is pinned here as a deliberate exception rather than leaving the high-severity hole open. The published 0.2.5 → 0.2.6 diff was reviewed before adopting it: the only change is the security fix (a new check that rejects `..` in prefix/postfix/template, plus a corrected directory-containment test), it adds no new dependencies and no install scripts, and it comes from the package's long-standing maintainer. `npm ci` installs the lockfile-pinned version irrespective of the age policy, so CI is unaffected.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ