### PR TITLE
PAE-250: Prune stale @hapi/content and tmp overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,14 +149,12 @@
     "webpack-cli": "7.0.2"
   },
   "overrides": {
-    "@hapi/content": "6.0.2",
     "eslint-plugin-import": {
       "eslint": "$eslint"
     },
     "stylelint-config-gds": {
       "stylelint": "$stylelint"
     },
-    "tmp": "0.2.6",
     "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

Two `overrides` entries that were once needed to force patched transitive dependencies have outlived their purpose. Removing `@hapi/content` and `tmp` and re-resolving the tree leaves both at safe versions on their own — `npm audit` and `snyk test` stay clean, and the full test suite passes — so the entries are removed.

The `uuid` override was tested the same way and is still required (without it, `exceljs` pulls a vulnerable `uuid` back in), so it's retained, as are the two nested compatibility overrides (`eslint-plugin-import`, `stylelint-config-gds`). The existing `postcss-selector-parser` Snyk ignore was also re-tested and still suppresses a live build-time finding, so it stays.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ