### PR TITLE
PAE-1466: show registered-only site when accreditation application is pending

### DIFF
--- a/src/server/organisations/controller.js
+++ b/src/server/organisations/controller.js
@@ -260,10 +260,14 @@ function getDisplayableRegistrations(organisationData) {
   )
 
   return organisationData.registrations
-    .map((registration) => ({
-      registration,
-      accreditation: accreditationById.get(registration.accreditationId)
-    }))
+    .map((registration) => {
+      const accreditation = accreditationById.get(registration.accreditationId)
+      return {
+        registration,
+        accreditation:
+          accreditation?.status === 'created' ? undefined : accreditation
+      }
+    })
     .filter(
       ({ registration, accreditation }) =>
         shouldRenderSite(registration, accreditation, 'reprocessor') ||

--- a/src/server/organisations/controller.test.js
+++ b/src/server/organisations/controller.test.js
@@ -3,7 +3,7 @@ import * as fetchOrganisationModule from '#server/common/helpers/organisations/f
 import * as fetchWasteBalancesModule from '#server/common/helpers/waste-balance/fetch-waste-balances.js'
 import { it } from '#vite/fixtures/server.js'
 import Boom from '@hapi/boom'
-import { getAllByRole, getByRole, getByText } from '@testing-library/dom'
+import { getAllByRole, getByRole } from '@testing-library/dom'
 import { load } from 'cheerio'
 import { JSDOM } from 'jsdom'
 import { beforeEach, describe, expect, vi } from 'vitest'
@@ -359,7 +359,7 @@ describe('#organisationController', () => {
         ]
       }
 
-      it('should exclude registrations whose accreditation has an excluded status', async ({
+      it('should show as registered-only when accreditation application is pending', async ({
         server
       }) => {
         vi.mocked(
@@ -393,9 +393,10 @@ describe('#organisationController', () => {
         })
 
         const { body } = new JSDOM(result).window.document
+        const cell = cellInColumn(getByRole(body, 'table'))
 
         expect(statusCode).toBe(statusCodes.ok)
-        expect(getByText(body, /No sites found/i)).toBeDefined()
+        expect(cell('Accreditation')).toHaveTextContent(/Not accredited/i)
       })
 
       it('should show registered-only', async ({ server }) => {


### PR DESCRIPTION
Ticket: [PAE-1466](https://eaflood.atlassian.net/browse/PAE-1466)
## Changes

- Treat a `created` (pending) accreditation as absent when resolving the registration-to-accreditation join in `getDisplayableRegistrations`
- A registered-only operator with a pending accreditation application now sees their site as registered-only rather than "No sites found"


[PAE-1466]: https://eaflood.atlassian.net/browse/PAE-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ