### PR TITLE
PAE-1339: derive tests typecheck scope from config

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -64,12 +64,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: DEFRA/epr-re-ex-service/.github/actions/lint-types-tests@main
-        with:
-          include-globs: |
-            **/*.test.js
-            **/test-helpers/**
-            **/test-fixtures.js
-            **/*.d.ts
 
   test-journey:
     name: Run Journey Tests

--- a/jsconfig.typecheck.tests.json
+++ b/jsconfig.typecheck.tests.json
@@ -4,10 +4,12 @@
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": [
-    "src/**/*.test.js",
-    "src/**/test-helpers/**/*.js",
-    "src/**/test-fixtures.js",
-    "src/**/*.d.ts"
+    "**/*.test.js",
+    "**/*.contract.js",
+    "**/*-test-helpers.js",
+    "**/test-helpers/**/*.js",
+    "**/test-fixtures.js",
+    "**/*.d.ts"
   ],
   "exclude": ["node_modules", ".vite"]
 }

--- a/jsconfig.typecheck.tests.json
+++ b/jsconfig.typecheck.tests.json
@@ -6,7 +6,6 @@
   "include": [
     "**/*.test.js",
     "**/*.contract.js",
-    "**/*-test-helpers.js",
     "**/test-helpers/**/*.js",
     "**/test-fixtures.js",
     "**/*.d.ts"


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

drop the duplicated include-globs block now the shared action derives scope from the tests config. unanchor the tests tsconfig globs so all test files are covered, not just src/.

depends on DEFRA/epr-re-ex-service#227 (merge that first).

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ