### PR TITLE
PAE-1466: Use isAccreditationActive helper to filter non-live accreditations

### DIFF
--- a/src/server/common/helpers/organisations/accreditation-helpers.js
+++ b/src/server/common/helpers/organisations/accreditation-helpers.js
@@ -1,0 +1,13 @@
+/** @import { Accreditation } from '#domain/organisations/accreditation.js' */
+
+const ACTIVE_ACCREDITATION_STATUSES = new Set(['approved', 'suspended'])
+
+/**
+ * Returns true when the accreditation is live (approved or suspended).
+ * A 'created', 'rejected', or 'cancelled' accreditation must be treated as
+ * registered-only — it has never been active.
+ * @param {Accreditation | undefined | null} accreditation
+ * @returns {boolean}
+ */
+export const isAccreditationActive = (accreditation) =>
+  !!accreditation && ACTIVE_ACCREDITATION_STATUSES.has(accreditation.status)

--- a/src/server/common/helpers/organisations/accreditation-helpers.test.js
+++ b/src/server/common/helpers/organisations/accreditation-helpers.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { isAccreditationActive } from './accreditation-helpers.js'
+
+describe(isAccreditationActive, () => {
+  it.each([
+    { status: 'approved', expected: true },
+    { status: 'suspended', expected: true },
+    { status: 'created', expected: false },
+    { status: 'rejected', expected: false },
+    { status: 'cancelled', expected: false }
+  ])(
+    'returns $expected for accreditation with status "$status"',
+    ({ status, expected }) => {
+      expect(isAccreditationActive({ status })).toBe(expected)
+    }
+  )
+
+  it('returns false for undefined', () => {
+    expect(isAccreditationActive(undefined)).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isAccreditationActive(null)).toBe(false)
+  })
+})

--- a/src/server/common/helpers/organisations/accreditation-helpers.test.js
+++ b/src/server/common/helpers/organisations/accreditation-helpers.test.js
@@ -1,17 +1,65 @@
 import { describe, expect, it } from 'vitest'
 import { isAccreditationActive } from './accreditation-helpers.js'
 
+/** @import { Accreditation } from '#domain/organisations/accreditation.js' */
+
+const BASE = {
+  id: 'acc-1',
+  statusHistory: [],
+  formSubmissionTime: '2024-01-01T00:00:00.000Z',
+  material: 'plastic',
+  prnIssuance: {
+    incomeBusinessPlan: [],
+    signatories: [],
+    tonnageBand: 'small'
+  },
+  submittedToRegulator: 'ea',
+  submitterContactDetails: {
+    fullName: 'Test User',
+    email: 'test@example.com',
+    phone: '01234567890'
+  },
+  wasteProcessingType: 'reprocessor'
+}
+
+/** @type {Accreditation} */
+const APPROVED = {
+  ...BASE,
+  status: 'approved',
+  accreditationNumber: 'ACC-001',
+  validFrom: '2024-01-01',
+  validTo: '2024-12-31'
+}
+
+/** @type {Accreditation} */
+const SUSPENDED = {
+  ...BASE,
+  status: 'suspended',
+  accreditationNumber: 'ACC-001',
+  validFrom: '2024-01-01',
+  validTo: '2024-12-31'
+}
+
+/** @type {Accreditation} */
+const CREATED = { ...BASE, status: 'created' }
+
+/** @type {Accreditation} */
+const REJECTED = { ...BASE, status: 'rejected' }
+
+/** @type {Accreditation} */
+const ARCHIVED = { ...BASE, status: 'archived' }
+
 describe(isAccreditationActive, () => {
   it.each([
-    { status: 'approved', expected: true },
-    { status: 'suspended', expected: true },
-    { status: 'created', expected: false },
-    { status: 'rejected', expected: false },
-    { status: 'cancelled', expected: false }
+    { label: 'approved', accreditation: APPROVED, expected: true },
+    { label: 'suspended', accreditation: SUSPENDED, expected: true },
+    { label: 'created', accreditation: CREATED, expected: false },
+    { label: 'rejected', accreditation: REJECTED, expected: false },
+    { label: 'archived', accreditation: ARCHIVED, expected: false }
   ])(
-    'returns $expected for accreditation with status "$status"',
-    ({ status, expected }) => {
-      expect(isAccreditationActive({ status })).toBe(expected)
+    'returns $expected for $label accreditation',
+    ({ accreditation, expected }) => {
+      expect(isAccreditationActive(accreditation)).toBe(expected)
     }
   )
 

--- a/src/server/common/helpers/organisations/fetch-registration-and-accreditation.js
+++ b/src/server/common/helpers/organisations/fetch-registration-and-accreditation.js
@@ -1,5 +1,6 @@
 import { errorCodes } from '#server/common/enums/error-codes.js'
 import { notFound } from '#server/common/helpers/logging/cdp-boom.js'
+import { isAccreditationActive } from '#server/common/helpers/organisations/accreditation-helpers.js'
 import { fetchOrganisationById } from '#server/common/helpers/organisations/fetch-organisation-by-id.js'
 
 /**
@@ -43,14 +44,16 @@ async function fetchRegistrationAndAccreditation(
     })
   }
 
-  const accreditation = organisationData.accreditations.find(
+  const rawAccreditation = organisationData.accreditations.find(
     ({ id }) => id === registration.accreditationId
   )
 
   return {
     organisationData,
     registration,
-    accreditation
+    accreditation: isAccreditationActive(rawAccreditation)
+      ? rawAccreditation
+      : undefined
   }
 }
 

--- a/src/server/common/helpers/organisations/fetch-registration-and-accreditation.test.js
+++ b/src/server/common/helpers/organisations/fetch-registration-and-accreditation.test.js
@@ -187,6 +187,7 @@ describe(fetchRegistrationAndAccreditation, () => {
   test('passes correct parameters to fetchOrganisationById', async ({
     msw
   }) => {
+    /** @type {Request | undefined} */
     let capturedRequest
     msw.use(
       http.get(`${backendUrl}/v1/organisations/org-123`, ({ request }) => {
@@ -205,9 +206,9 @@ describe(fetchRegistrationAndAccreditation, () => {
       idToken
     )
 
-    expect(capturedRequest.headers.get('authorization')).toBe(
-      'Bearer test-id-token'
-    )
+    expect(
+      /** @type {Request} */ (capturedRequest).headers.get('authorization')
+    ).toBe('Bearer test-id-token')
   })
 
   test('propagates errors from fetchOrganisationById', async ({ msw }) => {

--- a/src/server/common/helpers/organisations/fetch-registration-and-accreditation.test.js
+++ b/src/server/common/helpers/organisations/fetch-registration-and-accreditation.test.js
@@ -21,7 +21,11 @@ describe(fetchRegistrationAndAccreditation, () => {
       id: organisationId,
       registrations: [{ id: registrationId, accreditationId }],
       accreditations: [
-        { id: accreditationId, accreditationNumber: 'ACC-2025-001' }
+        {
+          id: accreditationId,
+          accreditationNumber: 'ACC-2025-001',
+          status: 'approved'
+        }
       ]
     }
 
@@ -42,8 +46,43 @@ describe(fetchRegistrationAndAccreditation, () => {
       registration: { id: registrationId, accreditationId },
       accreditation: {
         id: accreditationId,
-        accreditationNumber: 'ACC-2025-001'
+        accreditationNumber: 'ACC-2025-001',
+        status: 'approved'
       }
+    })
+  })
+
+  test('returns undefined accreditation when accreditation status is created', async ({
+    msw
+  }) => {
+    const mockOrganisationData = {
+      id: organisationId,
+      registrations: [{ id: registrationId, accreditationId }],
+      accreditations: [
+        {
+          id: accreditationId,
+          accreditationNumber: 'ACC-2025-001',
+          status: 'created'
+        }
+      ]
+    }
+
+    msw.use(
+      http.get(`${backendUrl}/v1/organisations/org-123`, () =>
+        HttpResponse.json(mockOrganisationData)
+      )
+    )
+
+    const result = await fetchRegistrationAndAccreditation(
+      organisationId,
+      registrationId,
+      idToken
+    )
+
+    expect(result).toStrictEqual({
+      organisationData: mockOrganisationData,
+      registration: { id: registrationId, accreditationId },
+      accreditation: undefined
     })
   })
 

--- a/src/server/organisations/controller.js
+++ b/src/server/organisations/controller.js
@@ -2,6 +2,7 @@ import { capitalize } from 'lodash-es'
 
 import { formatTonnage } from '#config/nunjucks/filters/format-tonnage.js'
 import { getDisplayMaterial } from '#server/common/helpers/materials/get-display-material.js'
+import { isAccreditationActive } from '#server/common/helpers/organisations/accreditation-helpers.js'
 import { fetchOrganisationById } from '#server/common/helpers/organisations/fetch-organisation-by-id.js'
 import { isExporterRegistration } from '#server/common/helpers/prns/registration-helpers.js'
 import { fetchWasteBalances } from '#server/common/helpers/waste-balance/fetch-waste-balances.js'
@@ -23,20 +24,21 @@ import { getStatusClass } from './helpers/status-helpers.js'
  * @typedef {{ text: string, classes?: string, format?: string } | { html: string, classes?: string }} TableCell
  */
 
-const EXCLUDED_STATUSES = new Set(['created', 'rejected'])
+const EXCLUDED_REGISTRATION_STATUSES = new Set(['created', 'rejected'])
 
 /**
  * @param {string} [status]
  * @returns {boolean}
  */
-const isExcludedStatus = (status) => !status || EXCLUDED_STATUSES.has(status)
+const isRegistrationExcluded = (status) =>
+  !status || EXCLUDED_REGISTRATION_STATUSES.has(status)
 
 /**
  * @param {Accreditation | undefined} accreditation
  * @returns {boolean}
  */
 const excludeAccreditation = (accreditation) =>
-  accreditation !== undefined && isExcludedStatus(accreditation.status)
+  accreditation !== undefined && !isAccreditationActive(accreditation)
 
 /**
  * Determines whether a site should be rendered based on its registration
@@ -50,13 +52,11 @@ function shouldRenderSite(registration, accreditation, wasteProcessingType) {
   const isCorrectWasteProcessingType =
     registration.wasteProcessingType === wasteProcessingType
 
-  const isRegistrationExcluded = isExcludedStatus(registration.status)
+  const isRegExcluded = isRegistrationExcluded(registration.status)
   const isAccreditationExcluded = excludeAccreditation(accreditation)
 
   return (
-    isCorrectWasteProcessingType &&
-    !isRegistrationExcluded &&
-    !isAccreditationExcluded
+    isCorrectWasteProcessingType && !isRegExcluded && !isAccreditationExcluded
   )
 }
 
@@ -264,8 +264,9 @@ function getDisplayableRegistrations(organisationData) {
       const accreditation = accreditationById.get(registration.accreditationId)
       return {
         registration,
-        accreditation:
-          accreditation?.status === 'created' ? undefined : accreditation
+        accreditation: isAccreditationActive(accreditation)
+          ? accreditation
+          : undefined
       }
     })
     .filter(


### PR DESCRIPTION
Ticket: [PAE-1466](https://eaflood.atlassian.net/browse/PAE-1466)
Introduce `isAccreditationActive` helper and use it in `fetchRegistrationAndAccreditation` and the organisations controller to treat accreditations in `created`/`rejected`/`cancelled` state as absent.

[PAE-1466]: https://eaflood.atlassian.net/browse/PAE-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ