### PR TITLE
PAE-1538: clarify invalid-date cell error with dd/mm/yyyy format

### DIFF
--- a/src/server/summary-log/controller.test.js
+++ b/src/server/summary-log/controller.test.js
@@ -1511,7 +1511,11 @@ describe('#summaryLogUploadProgressController', () => {
           'UK_PACKAGING_WEIGHT_PERCENTAGE',
           'Must be 1 or less'
         ],
-        ['MUST_BE_A_VALID_DATE', 'DATE_OF_EXPORT', 'Must be a valid date'],
+        [
+          'MUST_BE_A_VALID_DATE',
+          'DATE_OF_EXPORT',
+          'Must be a valid date in the format dd/mm/yyyy'
+        ],
         ['MUST_BE_YES_OR_NO', 'BAILING_WIRE_PROTOCOL', 'Must be Yes or No'],
         [
           'MUST_BE_VALID_EWC_CODE',

--- a/src/server/summary-log/en.json
+++ b/src/server/summary-log/en.json
@@ -18,7 +18,7 @@
   "cellReason": {
     "CALCULATED_FIELD_MISMATCH": "Does not match the calculated value",
     "DATA_ENTRY_INVALID": "Check this value",
-    "DATE_FORMAT_INVALID": "Must be a valid date",
+    "DATE_FORMAT_INVALID": "Must be a valid date in the format dd/mm/yyyy",
     "DROPDOWN_FORMAT_INVALID": "Select a value from the drop-down list",
     "FREE_TEXT_INVALID": "Contains characters that are not allowed",
     "ID_FORMAT_INVALID": "Must be a 3-digit number",


### PR DESCRIPTION
Ticket: [PAE-1538](https://eaflood.atlassian.net/browse/PAE-1538)

amends the summary-log invalid-date cell error message.

- `DATE_FORMAT_INVALID` cell reason now reads "Must be a valid date in the format dd/mm/yyyy"


[PAE-1538]: https://eaflood.atlassian.net/browse/PAE-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ