### PR TITLE
PAE-1557: Remove orphaned reportsNotAvailable translation key

### DIFF
--- a/src/server/registrations/en.json
+++ b/src/server/registrations/en.json
@@ -19,7 +19,6 @@
   "registrationNumber": "Registration number",
   "reports": "Reports",
   "reportsDescription": "Create and manage your reports.",
-  "reportsNotAvailable": "Reporting is not yet available.",
   "summaryLog": "Summary log",
   "summaryLogDescription": "Upload your summary log to record new packaging waste or adjust previously submitted data.",
   "unknownSite": "Unknown site",


### PR DESCRIPTION
Ticket: [PAE-1557](https://eaflood.atlassian.net/browse/PAE-1557)
- Remove unused `reportsNotAvailable` translation key from `en.json`
- Key became orphaned after the template change in PAE-1557; no templates or code reference it

[PAE-1557]: https://eaflood.atlassian.net/browse/PAE-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ