### PR TITLE
PAE-1554: Add submissionNumber to report API calls and routes

### DIFF
--- a/src/server/reports/check-controller.js
+++ b/src/server/reports/check-controller.js
@@ -274,12 +274,14 @@ export const checkPostController = {
     const transition = { status: SUBMISSION_STATUS.READY_TO_SUBMIT, version }
 
     await updateReportStatus(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       transition,
       session.idToken
     )

--- a/src/server/reports/check-controller.js
+++ b/src/server/reports/check-controller.js
@@ -223,7 +223,7 @@ export const checkGetController = {
       )
     }
 
-    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
     const material = getDisplayMaterial(registration)
     const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
     const cadenceLabel = localise(`reports:${cadence}Heading`)
@@ -288,7 +288,7 @@ export const checkPostController = {
 
     return h.redirect(
       request.localiseUrl(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/created`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/created`
       )
     )
   }

--- a/src/server/reports/check-controller.js
+++ b/src/server/reports/check-controller.js
@@ -187,8 +187,14 @@ export const checkGetController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -205,6 +211,7 @@ export const checkGetController = {
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
 
@@ -216,7 +223,7 @@ export const checkGetController = {
       )
     }
 
-    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
     const material = getDisplayMaterial(registration)
     const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
     const cadenceLabel = localise(`reports:${cadence}Heading`)
@@ -253,8 +260,14 @@ export const checkPostController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const { version } = request.payload
     const session = request.auth.credentials
 
@@ -266,13 +279,14 @@ export const checkPostController = {
       year,
       cadence,
       period,
+      submissionNumber,
       transition,
       session.idToken
     )
 
     return h.redirect(
       request.localiseUrl(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/created`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/created`
       )
     )
   }

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -241,7 +241,7 @@ const accreditedExporterReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/check-your-answers`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/check-your-answers`
 
 describe('#checkController', () => {
   beforeEach(() => {
@@ -810,7 +810,7 @@ describe('#checkController', () => {
         expect(changeLink).not.toBeNull()
         expect(changeLink?.textContent).toContain('Change')
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
         )
       })
 
@@ -865,7 +865,7 @@ describe('#checkController', () => {
         expect(deleteLink).not.toBeNull()
         expect(deleteLink?.textContent).toContain('Delete and start again')
         expect(deleteLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/delete`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
         )
       })
 
@@ -903,7 +903,7 @@ describe('#checkController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
         )
       })
     })
@@ -1285,7 +1285,7 @@ describe('#checkController', () => {
         )
 
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-recycled`
         )
       })
 
@@ -1306,7 +1306,7 @@ describe('#checkController', () => {
         )
 
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
         )
       })
 
@@ -1717,7 +1717,7 @@ describe('#checkController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/created`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/created`
         )
       })
 
@@ -1742,6 +1742,7 @@ describe('#checkController', () => {
           2026,
           'quarterly',
           1,
+          1,
           { status: 'ready_to_submit', version: 1 },
           'mock-id-token'
         )
@@ -1751,7 +1752,7 @@ describe('#checkController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1763,7 +1764,7 @@ describe('#checkController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1775,7 +1776,7 @@ describe('#checkController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -1737,12 +1737,14 @@ describe('#checkController', () => {
         })
 
         expect(updateReportStatus).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'quarterly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'quarterly',
+            period: 1,
+            submissionNumber: 1
+          },
           { status: 'ready_to_submit', version: 1 },
           'mock-id-token'
         )

--- a/src/server/reports/check-controller.test.js
+++ b/src/server/reports/check-controller.test.js
@@ -241,7 +241,7 @@ const accreditedExporterReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/check-your-answers`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/check-your-answers`
 
 describe('#checkController', () => {
   beforeEach(() => {
@@ -810,7 +810,7 @@ describe('#checkController', () => {
         expect(changeLink).not.toBeNull()
         expect(changeLink?.textContent).toContain('Change')
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
         )
       })
 
@@ -865,7 +865,7 @@ describe('#checkController', () => {
         expect(deleteLink).not.toBeNull()
         expect(deleteLink?.textContent).toContain('Delete and start again')
         expect(deleteLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/delete`
         )
       })
 
@@ -903,7 +903,7 @@ describe('#checkController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
         )
       })
     })
@@ -1285,7 +1285,7 @@ describe('#checkController', () => {
         )
 
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-recycled`
         )
       })
 
@@ -1306,7 +1306,7 @@ describe('#checkController', () => {
         )
 
         expect(changeLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-not-recycled`
         )
       })
 
@@ -1717,7 +1717,7 @@ describe('#checkController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/created`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/created`
         )
       })
 
@@ -1754,7 +1754,7 @@ describe('#checkController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1766,7 +1766,7 @@ describe('#checkController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1778,7 +1778,7 @@ describe('#checkController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/check-your-answers`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/check-your-answers`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/create-controller.js
+++ b/src/server/reports/create-controller.js
@@ -13,8 +13,14 @@ export const createController = {
     }
   },
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
 
     const { registration, accreditation } =
@@ -33,6 +39,7 @@ export const createController = {
         year,
         cadence,
         period,
+        submissionNumber,
         session.idToken
       )
     } catch (error) {
@@ -45,7 +52,7 @@ export const createController = {
       }
     }
 
-    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
     const nextPage = `${basePath}${getInProgressActionPath(registration, accreditation, cadence)}`
 

--- a/src/server/reports/create-controller.js
+++ b/src/server/reports/create-controller.js
@@ -52,7 +52,7 @@ export const createController = {
       }
     }
 
-    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
     const nextPage = `${basePath}${getInProgressActionPath(registration, accreditation, cadence)}`
 

--- a/src/server/reports/create-controller.test.js
+++ b/src/server/reports/create-controller.test.js
@@ -98,7 +98,7 @@ const reportDetail = {
 }
 
 const detailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1'
+  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1'
 
 describe('#createReportController', () => {
   beforeEach(() => {
@@ -160,14 +160,14 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1/tonnes-recycled'
       )
     })
   })
 
   describe('for accredited exporter with monthly cadence', () => {
     const monthlyDetailUrl =
-      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
+      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1'
 
     beforeEach(() => {
       vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
@@ -201,7 +201,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/prn-summary'
       )
     })
   })
@@ -255,7 +255,7 @@ describe('#createReportController', () => {
       server
     }) => {
       const monthlyUrl =
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1'
 
       vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
         reprocessorRegistration
@@ -279,7 +279,7 @@ describe('#createReportController', () => {
 
   describe('for accredited reprocessor with monthly cadence', () => {
     const monthlyDetailUrl =
-      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
+      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1'
 
     const accreditedReprocessorRegistration = {
       ...reprocessorRegistration,
@@ -319,7 +319,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/tonnes-recycled'
       )
     })
   })
@@ -351,7 +351,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-not-exported'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1/tonnes-not-exported'
       )
     })
   })
@@ -387,7 +387,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/supporting-information'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1/supporting-information'
       )
     })
   })
@@ -420,7 +420,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1/tonnes-recycled'
       )
     })
   })

--- a/src/server/reports/create-controller.test.js
+++ b/src/server/reports/create-controller.test.js
@@ -98,7 +98,7 @@ const reportDetail = {
 }
 
 const detailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1'
+  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1'
 
 describe('#createReportController', () => {
   beforeEach(() => {
@@ -138,6 +138,7 @@ describe('#createReportController', () => {
         2026,
         'quarterly',
         1,
+        1,
         'mock-id-token'
       )
     })
@@ -159,14 +160,14 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-recycled'
       )
     })
   })
 
   describe('for accredited exporter with monthly cadence', () => {
     const monthlyDetailUrl =
-      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1'
+      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
 
     beforeEach(() => {
       vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
@@ -200,7 +201,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/prn-summary'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
       )
     })
   })
@@ -254,7 +255,7 @@ describe('#createReportController', () => {
       server
     }) => {
       const monthlyUrl =
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
 
       vi.mocked(fetchRegistrationAndAccreditation).mockResolvedValue(
         reprocessorRegistration
@@ -278,7 +279,7 @@ describe('#createReportController', () => {
 
   describe('for accredited reprocessor with monthly cadence', () => {
     const monthlyDetailUrl =
-      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1'
+      '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
 
     const accreditedReprocessorRegistration = {
       ...reprocessorRegistration,
@@ -318,7 +319,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/tonnes-recycled'
       )
     })
   })
@@ -350,7 +351,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/tonnes-not-exported'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-not-exported'
       )
     })
   })
@@ -386,7 +387,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/supporting-information'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/supporting-information'
       )
     })
   })
@@ -419,7 +420,7 @@ describe('#createReportController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1/tonnes-recycled'
       )
     })
   })

--- a/src/server/reports/created-controller.js
+++ b/src/server/reports/created-controller.js
@@ -20,8 +20,14 @@ export const createdController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -39,6 +45,7 @@ export const createdController = {
         year,
         cadence,
         period,
+        submissionNumber,
         session.idToken
       )
     ])
@@ -54,7 +61,7 @@ export const createdController = {
     const formattedDueDate = formatDate(reportDetail.dueDate)
 
     const homeUrl = `/organisations/${organisationId}`
-    const viewDraftUrl = `${reportsUrl}/${year}/${cadence}/${period}/view`
+    const viewDraftUrl = `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/view`
 
     return h.view('reports/created', {
       pageTitle: localise('reports:createdPageTitle', {

--- a/src/server/reports/created-controller.js
+++ b/src/server/reports/created-controller.js
@@ -61,7 +61,7 @@ export const createdController = {
     const formattedDueDate = formatDate(reportDetail.dueDate)
 
     const homeUrl = `/organisations/${organisationId}`
-    const viewDraftUrl = `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/view`
+    const viewDraftUrl = `${reportsUrl}/${year}/${cadence}/${period}/submissions/${submissionNumber}/view`
 
     return h.view('reports/created', {
       pageTitle: localise('reports:createdPageTitle', {

--- a/src/server/reports/created-controller.test.js
+++ b/src/server/reports/created-controller.test.js
@@ -61,7 +61,7 @@ const mockReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1`
+const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
 const createdUrl = `${basePeriodPath}/created`
 const listUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
@@ -350,7 +350,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/created`,
         auth: mockAuth
       })
 
@@ -360,7 +360,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/created`,
         auth: mockAuth
       })
 
@@ -370,7 +370,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid period', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/created`,
         auth: mockAuth
       })
 

--- a/src/server/reports/created-controller.test.js
+++ b/src/server/reports/created-controller.test.js
@@ -61,7 +61,7 @@ const mockReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
+const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1`
 const createdUrl = `${basePeriodPath}/created`
 const listUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
@@ -350,7 +350,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/created`,
         auth: mockAuth
       })
 
@@ -360,7 +360,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/created`,
         auth: mockAuth
       })
 
@@ -370,7 +370,7 @@ describe('#createdController', () => {
     it('should return 400 for invalid period', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/created`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/created`,
         auth: mockAuth
       })
 

--- a/src/server/reports/delete-controller.js
+++ b/src/server/reports/delete-controller.js
@@ -94,8 +94,14 @@ export const deletePostController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
 
     await deleteReport(
@@ -104,6 +110,7 @@ export const deletePostController = {
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
 

--- a/src/server/reports/delete-controller.test.js
+++ b/src/server/reports/delete-controller.test.js
@@ -39,7 +39,7 @@ const registeredOnlyExporter = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/delete`
 
 describe('#deleteController', () => {
   beforeEach(() => {
@@ -327,7 +327,7 @@ describe('#deleteController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -339,7 +339,7 @@ describe('#deleteController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -351,7 +351,7 @@ describe('#deleteController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/delete-controller.test.js
+++ b/src/server/reports/delete-controller.test.js
@@ -39,7 +39,7 @@ const registeredOnlyExporter = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/delete`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
 
 describe('#deleteController', () => {
   beforeEach(() => {
@@ -293,6 +293,7 @@ describe('#deleteController', () => {
           2026,
           'quarterly',
           1,
+          1,
           'mock-id-token'
         )
       })
@@ -326,7 +327,7 @@ describe('#deleteController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -338,7 +339,7 @@ describe('#deleteController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -350,7 +351,7 @@ describe('#deleteController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/delete`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/delete`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/detail-controller.js
+++ b/src/server/reports/detail-controller.js
@@ -182,8 +182,14 @@ export const detailController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -202,6 +208,7 @@ export const detailController = {
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
 

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -366,11 +366,11 @@ const emptyExporterReportDetail = {
 }
 
 const detailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1'
+  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1'
 const exporterDetailUrl =
-  '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1'
+  '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/submissions/1'
 const accreditedDetailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/2/1'
+  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/2/submissions/1'
 
 const accreditedExporterRegistration = {
   organisationData: { id: 'org-789' },
@@ -446,7 +446,7 @@ const accreditedExporterReportDetail = {
 }
 
 const accreditedExporterDetailUrl =
-  '/organisations/org-789/registrations/reg-003/reports/2026/monthly/2/1'
+  '/organisations/org-789/registrations/reg-003/reports/2026/monthly/2/submissions/1'
 
 describe('#detailReportsController', () => {
   beforeEach(() => {
@@ -1767,7 +1767,7 @@ describe('#detailReportsController', () => {
 
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/submissions/1',
         auth: mockAuth
       })
 
@@ -1783,7 +1783,7 @@ describe('#detailReportsController', () => {
 
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1',
         auth: mockAuth
       })
 
@@ -1809,7 +1809,7 @@ describe('#detailReportsController', () => {
     it('should return 400 for non-numeric year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/invalid/monthly/1/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/invalid/monthly/1/submissions/1',
         auth: mockAuth
       })
 
@@ -1819,7 +1819,7 @@ describe('#detailReportsController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/biweekly/1/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/biweekly/1/submissions/1',
         auth: mockAuth
       })
 

--- a/src/server/reports/detail-controller.test.js
+++ b/src/server/reports/detail-controller.test.js
@@ -366,11 +366,11 @@ const emptyExporterReportDetail = {
 }
 
 const detailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1'
+  '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1'
 const exporterDetailUrl =
-  '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1'
+  '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1'
 const accreditedDetailUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/2'
+  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/2/1'
 
 const accreditedExporterRegistration = {
   organisationData: { id: 'org-789' },
@@ -446,7 +446,7 @@ const accreditedExporterReportDetail = {
 }
 
 const accreditedExporterDetailUrl =
-  '/organisations/org-789/registrations/reg-003/reports/2026/monthly/2'
+  '/organisations/org-789/registrations/reg-003/reports/2026/monthly/2/1'
 
 describe('#detailReportsController', () => {
   beforeEach(() => {
@@ -1767,7 +1767,7 @@ describe('#detailReportsController', () => {
 
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/quarterly/1/1',
         auth: mockAuth
       })
 
@@ -1783,7 +1783,7 @@ describe('#detailReportsController', () => {
 
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1',
         auth: mockAuth
       })
 
@@ -1809,7 +1809,7 @@ describe('#detailReportsController', () => {
     it('should return 400 for non-numeric year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/invalid/monthly/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/invalid/monthly/1/1',
         auth: mockAuth
       })
 
@@ -1819,7 +1819,7 @@ describe('#detailReportsController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: '/organisations/org-123/registrations/reg-001/reports/2026/biweekly/1',
+        url: '/organisations/org-123/registrations/reg-001/reports/2026/biweekly/1/1',
         auth: mockAuth
       })
 

--- a/src/server/reports/exporter/exporter-page-guards.test.js
+++ b/src/server/reports/exporter/exporter-page-guards.test.js
@@ -31,7 +31,8 @@ const mockRequest = {
     registrationId: 'reg-001',
     year: 2026,
     cadence: 'monthly',
-    period: 1
+    period: 1,
+    submissionNumber: 1
   },
   auth: { credentials: { idToken: 'mock-id-token' } }
 }

--- a/src/server/reports/exporter/prn-summary-controller.test.js
+++ b/src/server/reports/exporter/prn-summary-controller.test.js
@@ -58,7 +58,7 @@ const reportDetail = {
 }
 
 const baseUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
+  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/prn-summary'
 
 describe('#prnSummaryDispatcher cross-registration routing', () => {
   beforeEach(() => {

--- a/src/server/reports/exporter/prn-summary-controller.test.js
+++ b/src/server/reports/exporter/prn-summary-controller.test.js
@@ -58,7 +58,7 @@ const reportDetail = {
 }
 
 const baseUrl =
-  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/prn-summary'
+  '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
 
 describe('#prnSummaryDispatcher cross-registration routing', () => {
   beforeEach(() => {

--- a/src/server/reports/exporter/tonnes-not-exported-controller.test.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.test.js
@@ -72,7 +72,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-not-exported`
+const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-exported`
 
 describe('#tonnesNotExportedController', () => {
   beforeEach(() => {
@@ -223,7 +223,7 @@ describe('#tonnesNotExportedController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
       )
     })
 
@@ -330,6 +330,7 @@ describe('#tonnesNotExportedController', () => {
         registrationId,
         2026,
         'quarterly',
+        1,
         1,
         { tonnageNotExported: 15.5 },
         'mock-id-token'

--- a/src/server/reports/exporter/tonnes-not-exported-controller.test.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.test.js
@@ -72,7 +72,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-exported`
+const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-not-exported`
 
 describe('#tonnesNotExportedController', () => {
   beforeEach(() => {
@@ -223,7 +223,7 @@ describe('#tonnesNotExportedController', () => {
 
       expect(statusCode).toBe(statusCodes.found)
       expect(headers.location).toBe(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
       )
     })
 

--- a/src/server/reports/exporter/tonnes-not-exported-controller.test.js
+++ b/src/server/reports/exporter/tonnes-not-exported-controller.test.js
@@ -326,12 +326,14 @@ describe('#tonnesNotExportedController', () => {
       })
 
       expect(updateReport).toHaveBeenCalledWith(
-        organisationId,
-        registrationId,
-        2026,
-        'quarterly',
-        1,
-        1,
+        {
+          organisationId,
+          registrationId,
+          year: 2026,
+          cadence: 'quarterly',
+          period: 1,
+          submissionNumber: 1
+        },
         { tonnageNotExported: 15.5 },
         'mock-id-token'
       )

--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -142,8 +142,14 @@ function createSimplePostHandler(fieldName, nextPage) {
     const fieldValue = request.payload[fieldName]
 
     if (fieldValue !== undefined) {
-      const { organisationId, registrationId, year, cadence, period } =
-        request.params
+      const {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      } = request.params
 
       await updateReport(
         organisationId,
@@ -151,6 +157,7 @@ function createSimplePostHandler(fieldName, nextPage) {
         year,
         cadence,
         period,
+        submissionNumber,
         { [fieldName]: fieldValue },
         request.auth.credentials.idToken
       )
@@ -225,8 +232,14 @@ function createTonnagePostHandler(
   viewPath
 ) {
   return async (request, h) => {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const fieldValue = /** @type {number | undefined} */ (
       request.payload[fieldName]
     )
@@ -249,6 +262,7 @@ function createTonnagePostHandler(
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
 
@@ -272,6 +286,7 @@ function createTonnagePostHandler(
       year,
       cadence,
       period,
+      submissionNumber,
       { [fieldName]: fieldValue },
       session.idToken
     )

--- a/src/server/reports/helpers/create-data-page-controllers.js
+++ b/src/server/reports/helpers/create-data-page-controllers.js
@@ -152,12 +152,14 @@ function createSimplePostHandler(fieldName, nextPage) {
       } = request.params
 
       await updateReport(
-        organisationId,
-        registrationId,
-        year,
-        cadence,
-        period,
-        submissionNumber,
+        {
+          organisationId,
+          registrationId,
+          year,
+          cadence,
+          period,
+          submissionNumber
+        },
         { [fieldName]: fieldValue },
         request.auth.credentials.idToken
       )
@@ -281,12 +283,14 @@ function createTonnagePostHandler(
     }
 
     await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { [fieldName]: fieldValue },
       session.idToken
     )

--- a/src/server/reports/helpers/create-free-tonnage-controllers.test.js
+++ b/src/server/reports/helpers/create-free-tonnage-controllers.test.js
@@ -101,7 +101,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
     prn: { ...reportDetail.prn, freeTonnage: 5 }
   }
 
-  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/${subtree.urlSlug}`
+  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/${subtree.urlSlug}`
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -227,7 +227,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
     })
 
     it('should return 404 for quarterly cadence', async ({ server }) => {
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/${subtree.urlSlug}`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/${subtree.urlSlug}`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -309,7 +309,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/supporting-information`
         )
       })
 

--- a/src/server/reports/helpers/create-free-tonnage-controllers.test.js
+++ b/src/server/reports/helpers/create-free-tonnage-controllers.test.js
@@ -101,7 +101,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
     prn: { ...reportDetail.prn, freeTonnage: 5 }
   }
 
-  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/${subtree.urlSlug}`
+  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/${subtree.urlSlug}`
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -227,7 +227,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
     })
 
     it('should return 404 for quarterly cadence', async ({ server }) => {
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/${subtree.urlSlug}`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/${subtree.urlSlug}`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -309,7 +309,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
         )
       })
 
@@ -331,6 +331,7 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
           registrationId,
           2026,
           'monthly',
+          1,
           1,
           { freeTonnage: 5 },
           'mock-id-token'

--- a/src/server/reports/helpers/create-free-tonnage-controllers.test.js
+++ b/src/server/reports/helpers/create-free-tonnage-controllers.test.js
@@ -327,12 +327,14 @@ describe.each(subtrees)('$name free tonnage page', (subtree) => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'monthly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'monthly',
+            period: 1,
+            submissionNumber: 1
+          },
           { freeTonnage: 5 },
           'mock-id-token'
         )

--- a/src/server/reports/helpers/create-page-guards.js
+++ b/src/server/reports/helpers/create-page-guards.js
@@ -208,7 +208,7 @@ async function buildViewData(
   const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
   const periodShort = formatPeriodShort({ year, period }, cadence, localise)
   const reportsListPath = `/organisations/${organisationId}/registrations/${registrationId}/reports`
-  const periodPath = `${reportsListPath}/${year}/${cadence}/${period}/${submissionNumber}`
+  const periodPath = `${reportsListPath}/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   const pageFields = buildPageFields({
     registration,

--- a/src/server/reports/helpers/create-page-guards.js
+++ b/src/server/reports/helpers/create-page-guards.js
@@ -21,8 +21,14 @@ import { formatPeriodLabel, formatPeriodShort } from './format-period-label.js'
  * }>}
  */
 async function fetchGuardedData(isMatchingRegistration, request) {
-  const { organisationId, registrationId, year, cadence, period } =
-    request.params
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = request.params
   const session = request.auth.credentials
 
   const [{ registration, accreditation }, reportDetail] = await Promise.all([
@@ -37,6 +43,7 @@ async function fetchGuardedData(isMatchingRegistration, request) {
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
   ])
@@ -175,8 +182,14 @@ async function buildViewData(
   buildPageFields,
   options = {}
 ) {
-  const { organisationId, registrationId, year, cadence, period } =
-    request.params
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = request.params
   const { t: localise } = request
 
   const { registration, accreditation, reportDetail } = options.accreditedOnly
@@ -195,7 +208,7 @@ async function buildViewData(
   const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
   const periodShort = formatPeriodShort({ year, period }, cadence, localise)
   const reportsListPath = `/organisations/${organisationId}/registrations/${registrationId}/reports`
-  const periodPath = `${reportsListPath}/${year}/${cadence}/${period}`
+  const periodPath = `${reportsListPath}/${year}/${cadence}/${period}/${submissionNumber}`
 
   const pageFields = buildPageFields({
     registration,

--- a/src/server/reports/helpers/create-page-guards.test.js
+++ b/src/server/reports/helpers/create-page-guards.test.js
@@ -55,7 +55,8 @@ const mockRequest = {
     registrationId: 'reg-001',
     year: 2026,
     cadence: 'monthly',
-    period: 1
+    period: 1,
+    submissionNumber: 1
   },
   auth: {
     credentials: {

--- a/src/server/reports/helpers/create-prn-summary-controllers.test.js
+++ b/src/server/reports/helpers/create-prn-summary-controllers.test.js
@@ -101,7 +101,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
     prn: { ...reportDetail.prn, totalRevenue: 1576.12 }
   }
 
-  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
+  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/prn-summary`
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -224,7 +224,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
     })
 
     it('should return 404 for quarterly cadence', async ({ server }) => {
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/prn-summary`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/prn-summary`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -308,7 +308,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/${subtree.redirectSlug}`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/${subtree.redirectSlug}`
         )
 
         expect(server.loggerMocks.info).toHaveBeenCalledWith({

--- a/src/server/reports/helpers/create-prn-summary-controllers.test.js
+++ b/src/server/reports/helpers/create-prn-summary-controllers.test.js
@@ -334,12 +334,14 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'monthly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'monthly',
+            period: 1,
+            submissionNumber: 1
+          },
           { prnRevenue: 1576.12 },
           'mock-id-token'
         )

--- a/src/server/reports/helpers/create-prn-summary-controllers.test.js
+++ b/src/server/reports/helpers/create-prn-summary-controllers.test.js
@@ -101,7 +101,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
     prn: { ...reportDetail.prn, totalRevenue: 1576.12 }
   }
 
-  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/prn-summary`
+  const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -224,7 +224,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
     })
 
     it('should return 404 for quarterly cadence', async ({ server }) => {
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/prn-summary`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/prn-summary`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -308,7 +308,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/${subtree.redirectSlug}`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/${subtree.redirectSlug}`
         )
 
         expect(server.loggerMocks.info).toHaveBeenCalledWith({
@@ -338,6 +338,7 @@ describe.each(subtrees)('$name prn summary page', (subtree) => {
           registrationId,
           2026,
           'monthly',
+          1,
           1,
           { prnRevenue: 1576.12 },
           'mock-id-token'

--- a/src/server/reports/helpers/create-report.js
+++ b/src/server/reports/helpers/create-report.js
@@ -27,7 +27,7 @@ export async function createReport(
   submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/submissions/${submissionNumber}`
 
   return fetchJsonFromBackend(path, {
     method: 'POST',

--- a/src/server/reports/helpers/create-report.js
+++ b/src/server/reports/helpers/create-report.js
@@ -14,6 +14,7 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @param {string} idToken
  * @returns {Promise<CreateReportResponse>}
  */
@@ -23,9 +24,10 @@ export async function createReport(
   year,
   cadence,
   period,
+  submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
 
   return fetchJsonFromBackend(path, {
     method: 'POST',

--- a/src/server/reports/helpers/create-report.test.js
+++ b/src/server/reports/helpers/create-report.test.js
@@ -15,6 +15,7 @@ describe(createReport, () => {
   const year = 2026
   const cadence = 'monthly'
   const period = 1
+  const submissionNumber = 1
   const idToken = 'test-token'
 
   const mockResponse = {
@@ -35,11 +36,12 @@ describe(createReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/1',
       {
         method: 'POST',
         headers: {
@@ -52,10 +54,18 @@ describe(createReport, () => {
   it('encodes URL path parameters with special characters', async () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
-    await createReport('org/123', 'reg&456', year, 'quarterly', period, idToken)
+    await createReport(
+      'org/123',
+      'reg&456',
+      year,
+      'quarterly',
+      period,
+      submissionNumber,
+      idToken
+    )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
       expect.any(Object)
     )
   })
@@ -69,6 +79,7 @@ describe(createReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
@@ -86,6 +97,7 @@ describe(createReport, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         idToken
       )
     ).rejects.toThrow('Network error')

--- a/src/server/reports/helpers/create-report.test.js
+++ b/src/server/reports/helpers/create-report.test.js
@@ -41,7 +41,7 @@ describe(createReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/submissions/1',
       {
         method: 'POST',
         headers: {
@@ -65,7 +65,7 @@ describe(createReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/submissions/1',
       expect.any(Object)
     )
   })

--- a/src/server/reports/helpers/delete-report.js
+++ b/src/server/reports/helpers/delete-report.js
@@ -7,6 +7,7 @@ import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-bac
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @param {string} idToken
  * @returns {Promise<void>}
  */
@@ -16,9 +17,10 @@ export async function deleteReport(
   year,
   cadence,
   period,
+  submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
 
   return fetchJsonFromBackend(path, {
     method: 'DELETE',

--- a/src/server/reports/helpers/delete-report.js
+++ b/src/server/reports/helpers/delete-report.js
@@ -20,7 +20,7 @@ export async function deleteReport(
   submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/submissions/${submissionNumber}`
 
   return fetchJsonFromBackend(path, {
     method: 'DELETE',

--- a/src/server/reports/helpers/delete-report.test.js
+++ b/src/server/reports/helpers/delete-report.test.js
@@ -15,6 +15,7 @@ describe(deleteReport, () => {
   const year = 2026
   const cadence = 'monthly'
   const period = 1
+  const submissionNumber = 1
   const idToken = 'test-token'
 
   beforeEach(() => {
@@ -30,11 +31,12 @@ describe(deleteReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/1',
       {
         method: 'DELETE',
         headers: {
@@ -47,10 +49,18 @@ describe(deleteReport, () => {
   it('encodes URL path parameters with special characters', async () => {
     fetchJsonFromBackend.mockResolvedValue(undefined)
 
-    await deleteReport('org/123', 'reg&456', year, 'quarterly', period, idToken)
+    await deleteReport(
+      'org/123',
+      'reg&456',
+      year,
+      'quarterly',
+      period,
+      submissionNumber,
+      idToken
+    )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
       expect.any(Object)
     )
   })
@@ -66,6 +76,7 @@ describe(deleteReport, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         idToken
       )
     ).rejects.toThrow('Network error')

--- a/src/server/reports/helpers/delete-report.test.js
+++ b/src/server/reports/helpers/delete-report.test.js
@@ -36,7 +36,7 @@ describe(deleteReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/monthly/1/submissions/1',
       {
         method: 'DELETE',
         headers: {
@@ -60,7 +60,7 @@ describe(deleteReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/submissions/1',
       expect.any(Object)
     )
   })

--- a/src/server/reports/helpers/fetch-report-detail.js
+++ b/src/server/reports/helpers/fetch-report-detail.js
@@ -24,7 +24,7 @@ export async function fetchReportDetail(
   submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/submissions/${submissionNumber}`
 
   const report = await fetchReportBackend(path, {
     method: 'GET',

--- a/src/server/reports/helpers/fetch-report-detail.js
+++ b/src/server/reports/helpers/fetch-report-detail.js
@@ -11,6 +11,7 @@ import { SummaryLogChangedError } from './summary-log-changed.js'
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @param {string} idToken
  * @returns {Promise<ReportDetailResponse>}
  */
@@ -20,9 +21,10 @@ export async function fetchReportDetail(
   year,
   cadence,
   period,
+  submissionNumber,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
 
   const report = await fetchReportBackend(path, {
     method: 'GET',

--- a/src/server/reports/helpers/fetch-report-detail.test.js
+++ b/src/server/reports/helpers/fetch-report-detail.test.js
@@ -17,6 +17,7 @@ describe(fetchReportDetail, () => {
   const year = 2026
   const cadence = 'quarterly'
   const period = 1
+  const submissionNumber = 1
   const idToken = 'test-token'
 
   const mockResponse = {
@@ -76,11 +77,12 @@ describe(fetchReportDetail, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
       {
         method: 'GET',
         headers: {
@@ -99,11 +101,12 @@ describe(fetchReportDetail, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
       expect.any(Object)
     )
   })
@@ -117,6 +120,7 @@ describe(fetchReportDetail, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     )
 
@@ -134,6 +138,7 @@ describe(fetchReportDetail, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         idToken
       )
     ).rejects.toThrow('Network error')
@@ -155,6 +160,7 @@ describe(fetchReportDetail, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         idToken
       )
     ).rejects.toBeInstanceOf(SummaryLogChangedError)
@@ -175,6 +181,7 @@ describe(fetchReportDetail, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       idToken
     ).catch((e) => e)
 

--- a/src/server/reports/helpers/fetch-report-detail.test.js
+++ b/src/server/reports/helpers/fetch-report-detail.test.js
@@ -82,7 +82,7 @@ describe(fetchReportDetail, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/submissions/1',
       {
         method: 'GET',
         headers: {
@@ -106,7 +106,7 @@ describe(fetchReportDetail, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/submissions/1',
       expect.any(Object)
     )
   })

--- a/src/server/reports/helpers/fetch-reporting-periods.js
+++ b/src/server/reports/helpers/fetch-reporting-periods.js
@@ -37,6 +37,7 @@ export async function fetchReportingPeriods(
  * @typedef {{
  *   year: number,
  *   period: number,
+ *   submissionNumber: number,
  *   startDate: string,
  *   endDate: string,
  *   dueDate: string,

--- a/src/server/reports/helpers/period-params-schema.js
+++ b/src/server/reports/helpers/period-params-schema.js
@@ -13,7 +13,8 @@ import { CADENCE } from '../constants.js'
  *   registrationId: string,
  *   year: number,
  *   cadence: CadenceValue,
- *   period: number
+ *   period: number,
+ *   submissionNumber: number
  * }} PeriodParams
  */
 
@@ -26,5 +27,6 @@ export const periodParamsSchema = Joi.object({
   registrationId: Joi.string().required(),
   year: Joi.number().integer().min(MIN_YEAR).max(MAX_YEAR).required(),
   cadence: Joi.string().valid(CADENCE.MONTHLY, CADENCE.QUARTERLY).required(),
-  period: Joi.number().integer().min(1).max(MAX_PERIOD).required()
+  period: Joi.number().integer().min(1).max(MAX_PERIOD).required(),
+  submissionNumber: Joi.number().integer().min(1).required()
 })

--- a/src/server/reports/helpers/redirect.js
+++ b/src/server/reports/helpers/redirect.js
@@ -1,18 +1,25 @@
 /**
  * Returns the redirect URL for save (reports list) or continue (next page).
  * @param {HapiRequest} request
- * @param {{ organisationId: string, registrationId: string, year: number, cadence: CadenceValue, period: number }} params
+ * @param {{ organisationId: string, registrationId: string, year: number, cadence: CadenceValue, period: number, submissionNumber: number }} params
  * @param {string} action - 'continue' or 'save'
  * @param {string} nextPage - path segment for the continue destination (e.g. 'free-perns')
  * @returns {string}
  */
 export function getRedirectUrl(request, params, action, nextPage) {
-  const { organisationId, registrationId, year, cadence, period } = params
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = params
   const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
   if (action === 'continue') {
     return request.localiseUrl(
-      `${basePath}/${year}/${cadence}/${period}/${nextPage}`
+      `${basePath}/${year}/${cadence}/${period}/${submissionNumber}/${nextPage}`
     )
   }
 

--- a/src/server/reports/helpers/redirect.js
+++ b/src/server/reports/helpers/redirect.js
@@ -19,7 +19,7 @@ export function getRedirectUrl(request, params, action, nextPage) {
 
   if (action === 'continue') {
     return request.localiseUrl(
-      `${basePath}/${year}/${cadence}/${period}/${submissionNumber}/${nextPage}`
+      `${basePath}/${year}/${cadence}/${period}/submissions/${submissionNumber}/${nextPage}`
     )
   }
 

--- a/src/server/reports/helpers/update-report-status.js
+++ b/src/server/reports/helpers/update-report-status.js
@@ -16,7 +16,7 @@ export async function updateReportStatus(periodParams, transition, idToken) {
     period,
     submissionNumber
   } = periodParams
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}/status`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/submissions/${submissionNumber}/status`
 
   return fetchReportBackend(path, {
     method: 'POST',

--- a/src/server/reports/helpers/update-report-status.js
+++ b/src/server/reports/helpers/update-report-status.js
@@ -2,26 +2,20 @@ import { fetchReportBackend } from './fetch-report-backend.js'
 
 /**
  * Transitions a report's status via the backend POST endpoint.
- * @param {string} organisationId
- * @param {string} registrationId
- * @param {number} year
- * @param {string} cadence
- * @param {number} period
- * @param {number} submissionNumber
+ * @param {{ organisationId: string, registrationId: string, year: number, cadence: string, period: number, submissionNumber: number }} periodParams
  * @param {{ status: string, version: number }} transition - The target status and report version for optimistic locking
  * @param {string} idToken
  * @returns {Promise<unknown>}
  */
-export async function updateReportStatus(
-  organisationId,
-  registrationId,
-  year,
-  cadence,
-  period,
-  submissionNumber,
-  transition,
-  idToken
-) {
+export async function updateReportStatus(periodParams, transition, idToken) {
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = periodParams
   const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}/status`
 
   return fetchReportBackend(path, {

--- a/src/server/reports/helpers/update-report-status.js
+++ b/src/server/reports/helpers/update-report-status.js
@@ -7,6 +7,7 @@ import { fetchReportBackend } from './fetch-report-backend.js'
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @param {{ status: string, version: number }} transition - The target status and report version for optimistic locking
  * @param {string} idToken
  * @returns {Promise<unknown>}
@@ -17,10 +18,11 @@ export async function updateReportStatus(
   year,
   cadence,
   period,
+  submissionNumber,
   transition,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/status`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}/status`
 
   return fetchReportBackend(path, {
     method: 'POST',

--- a/src/server/reports/helpers/update-report-status.test.js
+++ b/src/server/reports/helpers/update-report-status.test.js
@@ -28,12 +28,14 @@ describe(updateReportStatus, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReportStatus(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
@@ -54,12 +56,14 @@ describe(updateReportStatus, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReportStatus(
-      'org/123',
-      'reg&456',
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId: 'org/123',
+        registrationId: 'reg&456',
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
@@ -74,12 +78,14 @@ describe(updateReportStatus, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     const result = await updateReportStatus(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
@@ -93,12 +99,14 @@ describe(updateReportStatus, () => {
 
     await expect(
       updateReportStatus(
-        organisationId,
-        registrationId,
-        year,
-        cadence,
-        period,
-        submissionNumber,
+        {
+          organisationId,
+          registrationId,
+          year,
+          cadence,
+          period,
+          submissionNumber
+        },
         'ready_to_submit',
         idToken
       )

--- a/src/server/reports/helpers/update-report-status.test.js
+++ b/src/server/reports/helpers/update-report-status.test.js
@@ -15,6 +15,7 @@ describe(updateReportStatus, () => {
   const year = 2026
   const cadence = 'quarterly'
   const period = 1
+  const submissionNumber = 1
   const idToken = 'test-token'
 
   const mockResponse = { ok: true }
@@ -32,12 +33,13 @@ describe(updateReportStatus, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/status',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1/status',
       {
         method: 'POST',
         headers: {
@@ -57,12 +59,13 @@ describe(updateReportStatus, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/status',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1/status',
       expect.any(Object)
     )
   })
@@ -76,6 +79,7 @@ describe(updateReportStatus, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { status: 'ready_to_submit', version: 1 },
       idToken
     )
@@ -94,8 +98,8 @@ describe(updateReportStatus, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         'ready_to_submit',
-        1,
         idToken
       )
     ).rejects.toThrow('Network error')

--- a/src/server/reports/helpers/update-report-status.test.js
+++ b/src/server/reports/helpers/update-report-status.test.js
@@ -41,7 +41,7 @@ describe(updateReportStatus, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1/status',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/submissions/1/status',
       {
         method: 'POST',
         headers: {
@@ -69,7 +69,7 @@ describe(updateReportStatus, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1/status',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/submissions/1/status',
       expect.any(Object)
     )
   })

--- a/src/server/reports/helpers/update-report.js
+++ b/src/server/reports/helpers/update-report.js
@@ -2,26 +2,20 @@ import { fetchReportBackend } from './fetch-report-backend.js'
 
 /**
  * Updates a report via the backend PATCH endpoint.
- * @param {string} organisationId
- * @param {string} registrationId
- * @param {number} year
- * @param {string} cadence
- * @param {number} period
- * @param {number} submissionNumber
+ * @param {{ organisationId: string, registrationId: string, year: number, cadence: string, period: number, submissionNumber: number }} periodParams
  * @param {Record<string, unknown>} fields - Fields to update (e.g. { supportingInformation } or { status })
  * @param {string} idToken
  * @returns {Promise<unknown>}
  */
-export async function updateReport(
-  organisationId,
-  registrationId,
-  year,
-  cadence,
-  period,
-  submissionNumber,
-  fields,
-  idToken
-) {
+export async function updateReport(periodParams, fields, idToken) {
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = periodParams
   const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
 
   return fetchReportBackend(path, {

--- a/src/server/reports/helpers/update-report.js
+++ b/src/server/reports/helpers/update-report.js
@@ -7,6 +7,7 @@ import { fetchReportBackend } from './fetch-report-backend.js'
  * @param {number} year
  * @param {string} cadence
  * @param {number} period
+ * @param {number} submissionNumber
  * @param {Record<string, unknown>} fields - Fields to update (e.g. { supportingInformation } or { status })
  * @param {string} idToken
  * @returns {Promise<unknown>}
@@ -17,10 +18,11 @@ export async function updateReport(
   year,
   cadence,
   period,
+  submissionNumber,
   fields,
   idToken
 ) {
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
 
   return fetchReportBackend(path, {
     method: 'PATCH',

--- a/src/server/reports/helpers/update-report.js
+++ b/src/server/reports/helpers/update-report.js
@@ -16,7 +16,7 @@ export async function updateReport(periodParams, fields, idToken) {
     period,
     submissionNumber
   } = periodParams
-  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/${submissionNumber}`
+  const path = `/v1/organisations/${encodeURIComponent(organisationId)}/registrations/${encodeURIComponent(registrationId)}/reports/${year}/${encodeURIComponent(cadence)}/${period}/submissions/${submissionNumber}`
 
   return fetchReportBackend(path, {
     method: 'PATCH',

--- a/src/server/reports/helpers/update-report.test.js
+++ b/src/server/reports/helpers/update-report.test.js
@@ -15,6 +15,7 @@ describe(updateReport, () => {
   const year = 2026
   const cadence = 'quarterly'
   const period = 1
+  const submissionNumber = 1
   const idToken = 'test-token'
 
   const mockResponse = { ok: true }
@@ -32,12 +33,13 @@ describe(updateReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { supportingInformation: 'Supply chain disruption in February' },
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
       {
         method: 'PATCH',
         headers: {
@@ -59,12 +61,13 @@ describe(updateReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { status: 'ready_to_submit' },
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
       {
         method: 'PATCH',
         headers: {
@@ -84,6 +87,7 @@ describe(updateReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { supportingInformation: '' },
       idToken
     )
@@ -105,12 +109,13 @@ describe(updateReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { supportingInformation: 'notes' },
       idToken
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
       expect.any(Object)
     )
   })
@@ -124,6 +129,7 @@ describe(updateReport, () => {
       year,
       cadence,
       period,
+      submissionNumber,
       { supportingInformation: 'notes' },
       idToken
     )
@@ -142,6 +148,7 @@ describe(updateReport, () => {
         year,
         cadence,
         period,
+        submissionNumber,
         { supportingInformation: 'notes' },
         idToken
       )

--- a/src/server/reports/helpers/update-report.test.js
+++ b/src/server/reports/helpers/update-report.test.js
@@ -28,12 +28,14 @@ describe(updateReport, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { supportingInformation: 'Supply chain disruption in February' },
       idToken
     )
@@ -56,12 +58,14 @@ describe(updateReport, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { status: 'ready_to_submit' },
       idToken
     )
@@ -82,12 +86,14 @@ describe(updateReport, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { supportingInformation: '' },
       idToken
     )
@@ -104,12 +110,14 @@ describe(updateReport, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     await updateReport(
-      'org/123',
-      'reg&456',
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId: 'org/123',
+        registrationId: 'reg&456',
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { supportingInformation: 'notes' },
       idToken
     )
@@ -124,12 +132,14 @@ describe(updateReport, () => {
     fetchJsonFromBackend.mockResolvedValue(mockResponse)
 
     const result = await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { supportingInformation: 'notes' },
       idToken
     )
@@ -143,12 +153,14 @@ describe(updateReport, () => {
 
     await expect(
       updateReport(
-        organisationId,
-        registrationId,
-        year,
-        cadence,
-        period,
-        submissionNumber,
+        {
+          organisationId,
+          registrationId,
+          year,
+          cadence,
+          period,
+          submissionNumber
+        },
         { supportingInformation: 'notes' },
         idToken
       )

--- a/src/server/reports/helpers/update-report.test.js
+++ b/src/server/reports/helpers/update-report.test.js
@@ -41,7 +41,7 @@ describe(updateReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/submissions/1',
       {
         method: 'PATCH',
         headers: {
@@ -71,7 +71,7 @@ describe(updateReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org-123/registrations/reg-456/reports/2026/quarterly/1/submissions/1',
       {
         method: 'PATCH',
         headers: {
@@ -123,7 +123,7 @@ describe(updateReport, () => {
     )
 
     expect(fetchJsonFromBackend).toHaveBeenCalledWith(
-      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/1',
+      '/v1/organisations/org%2F123/registrations/reg%26456/reports/2026/quarterly/1/submissions/1',
       expect.any(Object)
     )
   })

--- a/src/server/reports/index.js
+++ b/src/server/reports/index.js
@@ -58,7 +58,7 @@ export const reports = {
   plugin: {
     name: 'reports',
     register(server) {
-      const periodPath = `${basePath}/{year}/{cadence}/{period}/{submissionNumber}`
+      const periodPath = `${basePath}/{year}/{cadence}/{period}/submissions/{submissionNumber}`
 
       server.route([
         {
@@ -221,7 +221,7 @@ export const reports = {
             period,
             submissionNumber
           } = request.params
-          const base = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+          const base = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
           request.yar.set('summaryLogChangedError', base)
           return h.redirect(request.localiseUrl(`${base}/${errorRoute}`))
         },

--- a/src/server/reports/index.js
+++ b/src/server/reports/index.js
@@ -58,7 +58,7 @@ export const reports = {
   plugin: {
     name: 'reports',
     register(server) {
-      const periodPath = `${basePath}/{year}/{cadence}/{period}`
+      const periodPath = `${basePath}/{year}/{cadence}/{period}/{submissionNumber}`
 
       server.route([
         {
@@ -213,9 +213,15 @@ export const reports = {
           if (!errorRoute) {
             return h.continue
           }
-          const { organisationId, registrationId, year, cadence, period } =
-            request.params
-          const base = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+          const {
+            organisationId,
+            registrationId,
+            year,
+            cadence,
+            period,
+            submissionNumber
+          } = request.params
+          const base = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
           request.yar.set('summaryLogChangedError', base)
           return h.redirect(request.localiseUrl(`${base}/${errorRoute}`))
         },

--- a/src/server/reports/index.test.js
+++ b/src/server/reports/index.test.js
@@ -24,7 +24,8 @@ const registrationId = 'reg-001'
 const year = 2026
 const cadence = 'quarterly'
 const period = 1
-const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+const submissionNumber = 1
+const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 const detailUrl = periodBase
 
 /** @type {RegistrationWithAccreditation} */

--- a/src/server/reports/index.test.js
+++ b/src/server/reports/index.test.js
@@ -25,7 +25,7 @@ const year = 2026
 const cadence = 'quarterly'
 const period = 1
 const submissionNumber = 1
-const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 const detailUrl = periodBase
 
 /** @type {RegistrationWithAccreditation} */

--- a/src/server/reports/list-controller.js
+++ b/src/server/reports/list-controller.js
@@ -148,7 +148,7 @@ function buildRows({
   const submittedRows = []
 
   for (const period of reportingPeriods) {
-    const periodPath = `/organisations/${organisationId}/registrations/${registration.id}/reports/${period.year}/${cadence}/${period.period}/${period.submissionNumber}`
+    const periodPath = `/organisations/${organisationId}/registrations/${registration.id}/reports/${period.year}/${cadence}/${period.period}/submissions/${period.submissionNumber}`
 
     const label = formatPeriodLabel(period, cadence, localise)
 

--- a/src/server/reports/list-controller.js
+++ b/src/server/reports/list-controller.js
@@ -148,7 +148,7 @@ function buildRows({
   const submittedRows = []
 
   for (const period of reportingPeriods) {
-    const periodPath = `/organisations/${organisationId}/registrations/${registration.id}/reports/${period.year}/${cadence}/${period.period}`
+    const periodPath = `/organisations/${organisationId}/registrations/${registration.id}/reports/${period.year}/${cadence}/${period.period}/${period.submissionNumber}`
 
     const label = formatPeriodLabel(period, cadence, localise)
 

--- a/src/server/reports/list-controller.test.js
+++ b/src/server/reports/list-controller.test.js
@@ -427,7 +427,7 @@ describe('#listReportsController', () => {
 
       expect(selectLinks).toHaveLength(3)
       expect(selectLinks[0]?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1'
       )
       expect(selectLinks[0]?.textContent).toContain('Select')
     })
@@ -566,7 +566,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('Continue')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/tonnes-recycled'
       )
     })
 
@@ -589,7 +589,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/prn-summary'
       )
     })
 
@@ -656,7 +656,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('Review and submit')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/submit'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/submit'
       )
     })
   })
@@ -703,7 +703,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('View')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/view'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1/view'
       )
     })
 
@@ -1005,7 +1005,7 @@ describe('#listReportsController', () => {
 
       expect(selectLinks).toHaveLength(1)
       expect(selectLinks[0]?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/submissions/1'
       )
       expect(selectLinks[0]?.textContent).toContain('Select')
     })
@@ -1045,7 +1045,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1/tonnes-not-exported'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/submissions/1/tonnes-not-exported'
       )
     })
 
@@ -1091,7 +1091,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1/supporting-information'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/submissions/1/supporting-information'
       )
     })
 
@@ -1153,7 +1153,7 @@ describe('#listReportsController', () => {
 
       expect(link).not.toBeNull()
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-789/registrations/reg-003/reports/2026/quarterly/1/1'
+        '/organisations/org-789/registrations/reg-003/reports/2026/quarterly/1/submissions/1'
       )
       expect(link?.textContent).toContain('Select')
 

--- a/src/server/reports/list-controller.test.js
+++ b/src/server/reports/list-controller.test.js
@@ -114,6 +114,7 @@ const monthlyResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-01-31',
       dueDate: '2026-02-20',
@@ -122,6 +123,7 @@ const monthlyResponse = {
     {
       year: 2026,
       period: 2,
+      submissionNumber: 1,
       startDate: '2026-02-01',
       endDate: '2026-02-28',
       dueDate: '2026-03-20',
@@ -130,6 +132,7 @@ const monthlyResponse = {
     {
       year: 2026,
       period: 3,
+      submissionNumber: 1,
       startDate: '2026-03-01',
       endDate: '2026-03-31',
       dueDate: '2026-04-20',
@@ -144,6 +147,7 @@ const quarterlyResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-03-31',
       dueDate: '2026-04-20',
@@ -158,6 +162,7 @@ const monthlyWithReportResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-01-31',
       dueDate: '2026-02-20',
@@ -177,6 +182,7 @@ const monthlyWithReadyToSubmitResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-01-31',
       dueDate: '2026-02-20',
@@ -196,6 +202,7 @@ const monthlyWithSubmittedResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-01-31',
       dueDate: '2026-02-20',
@@ -219,6 +226,7 @@ const monthlyMixedStatusResponse = {
     {
       year: 2026,
       period: 1,
+      submissionNumber: 1,
       startDate: '2026-01-01',
       endDate: '2026-01-31',
       dueDate: '2026-02-20',
@@ -236,6 +244,7 @@ const monthlyMixedStatusResponse = {
     {
       year: 2026,
       period: 2,
+      submissionNumber: 1,
       startDate: '2026-02-01',
       endDate: '2026-02-28',
       dueDate: '2026-03-20',
@@ -249,6 +258,7 @@ const monthlyMixedStatusResponse = {
     {
       year: 2026,
       period: 3,
+      submissionNumber: 1,
       startDate: '2026-03-01',
       endDate: '2026-03-31',
       dueDate: '2026-04-20',
@@ -417,7 +427,7 @@ describe('#listReportsController', () => {
 
       expect(selectLinks).toHaveLength(3)
       expect(selectLinks[0]?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1'
       )
       expect(selectLinks[0]?.textContent).toContain('Select')
     })
@@ -556,7 +566,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('Continue')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/tonnes-recycled'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/tonnes-recycled'
       )
     })
 
@@ -579,7 +589,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/prn-summary'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/prn-summary'
       )
     })
 
@@ -646,7 +656,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('Review and submit')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submit'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/submit'
       )
     })
   })
@@ -693,7 +703,7 @@ describe('#listReportsController', () => {
       expect(link).not.toBeNull()
       expect(link?.textContent).toContain('View')
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/view'
+        '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/1/view'
       )
     })
 
@@ -706,6 +716,7 @@ describe('#listReportsController', () => {
           {
             year: 2026,
             period: 1,
+            submissionNumber: 1,
             startDate: '2026-01-01',
             endDate: '2026-01-31',
             dueDate: '2026-02-20',
@@ -994,7 +1005,7 @@ describe('#listReportsController', () => {
 
       expect(selectLinks).toHaveLength(1)
       expect(selectLinks[0]?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1'
       )
       expect(selectLinks[0]?.textContent).toContain('Select')
     })
@@ -1008,6 +1019,7 @@ describe('#listReportsController', () => {
           {
             year: 2026,
             period: 1,
+            submissionNumber: 1,
             startDate: '2026-01-01',
             endDate: '2026-03-31',
             dueDate: '2026-04-20',
@@ -1033,7 +1045,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/tonnes-not-exported'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1/tonnes-not-exported'
       )
     })
 
@@ -1053,6 +1065,7 @@ describe('#listReportsController', () => {
           {
             year: 2026,
             period: 1,
+            submissionNumber: 1,
             startDate: '2026-01-01',
             endDate: '2026-03-31',
             dueDate: '2026-04-20',
@@ -1078,7 +1091,7 @@ describe('#listReportsController', () => {
       const link = body.querySelector('.govuk-table a.govuk-link')
 
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/supporting-information'
+        '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/1/supporting-information'
       )
     })
 
@@ -1140,7 +1153,7 @@ describe('#listReportsController', () => {
 
       expect(link).not.toBeNull()
       expect(link?.getAttribute('href')).toBe(
-        '/organisations/org-789/registrations/reg-003/reports/2026/quarterly/1'
+        '/organisations/org-789/registrations/reg-003/reports/2026/quarterly/1/1'
       )
       expect(link?.textContent).toContain('Select')
 

--- a/src/server/reports/prn-summary-dispatcher.test.js
+++ b/src/server/reports/prn-summary-dispatcher.test.js
@@ -53,7 +53,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/prn-summary`
 
 describe('#prnSummaryDispatcher', () => {
   beforeEach(() => {

--- a/src/server/reports/prn-summary-dispatcher.test.js
+++ b/src/server/reports/prn-summary-dispatcher.test.js
@@ -53,7 +53,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/prn-summary`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
 
 describe('#prnSummaryDispatcher', () => {
   beforeEach(() => {

--- a/src/server/reports/reprocessor/reprocessor-page-guards.test.js
+++ b/src/server/reports/reprocessor/reprocessor-page-guards.test.js
@@ -32,7 +32,8 @@ const mockRequest = {
     registrationId: 'reg-001',
     year: 2026,
     cadence: 'monthly',
-    period: 1
+    period: 1,
+    submissionNumber: 1
   },
   auth: { credentials: { idToken: 'mock-id-token' } }
 }

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
@@ -218,12 +218,14 @@ describe('#tonnesNotRecycledController', () => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'monthly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'monthly',
+            period: 1,
+            submissionNumber: 1
+          },
           { tonnageNotRecycled: 20 },
           'mock-id-token'
         )

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
@@ -70,8 +70,8 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/tonnes-not-recycled`
-const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-not-recycled`
+const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-not-recycled`
+const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
 
 describe('#tonnesNotRecycledController', () => {
   beforeEach(() => {
@@ -194,7 +194,7 @@ describe('#tonnesNotRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/prn-summary`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
         )
       })
 
@@ -222,6 +222,7 @@ describe('#tonnesNotRecycledController', () => {
           registrationId,
           2026,
           'monthly',
+          1,
           1,
           { tonnageNotRecycled: 20 },
           'mock-id-token'
@@ -255,7 +256,7 @@ describe('#tonnesNotRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
         )
       })
     })

--- a/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-not-recycled-controller.test.js
@@ -70,8 +70,8 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-not-recycled`
-const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
+const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/tonnes-not-recycled`
+const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-not-recycled`
 
 describe('#tonnesNotRecycledController', () => {
   beforeEach(() => {
@@ -194,7 +194,7 @@ describe('#tonnesNotRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/prn-summary`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/prn-summary`
         )
       })
 
@@ -258,7 +258,7 @@ describe('#tonnesNotRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
         )
       })
     })

--- a/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
@@ -78,7 +78,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/tonnes-recycled`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-recycled`
 
 describe('#tonnesRecycledController', () => {
   beforeEach(() => {
@@ -151,7 +151,7 @@ describe('#tonnesRecycledController', () => {
         registeredOnlyReprocessor
       )
 
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-recycled`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-recycled`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -232,7 +232,7 @@ describe('#tonnesRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-not-recycled`
         )
       })
 
@@ -256,6 +256,7 @@ describe('#tonnesRecycledController', () => {
           registrationId,
           2026,
           'monthly',
+          1,
           1,
           { tonnageRecycled: 100.5 },
           'mock-id-token'

--- a/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
@@ -78,7 +78,7 @@ const reportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-recycled`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/tonnes-recycled`
 
 describe('#tonnesRecycledController', () => {
   beforeEach(() => {
@@ -151,7 +151,7 @@ describe('#tonnesRecycledController', () => {
         registeredOnlyReprocessor
       )
 
-      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-recycled`
+      const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-recycled`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -232,7 +232,7 @@ describe('#tonnesRecycledController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/tonnes-not-recycled`
         )
       })
 

--- a/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
+++ b/src/server/reports/reprocessor/tonnes-recycled-controller.test.js
@@ -252,12 +252,14 @@ describe('#tonnesRecycledController', () => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'monthly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'monthly',
+            period: 1,
+            submissionNumber: 1
+          },
           { tonnageRecycled: 100.5 },
           'mock-id-token'
         )

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -154,7 +154,7 @@ export const submitGetController = {
     if (status.currentStatus === SUBMISSION_STATUS.SUBMITTED) {
       return h.redirect(
         request.localiseUrl(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/submitted`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/submitted`
         )
       )
     }
@@ -339,7 +339,7 @@ function buildViewData({
     version: reportDetail.version,
 
     deleteUrl: localiseUrl(
-      `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/delete`
+      `${reportsUrl}/${year}/${cadence}/${period}/submissions/${submissionNumber}/delete`
     )
   }
 }
@@ -388,7 +388,7 @@ export const submitPostController = {
 
     return h.redirect(
       request.localiseUrl(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/submitted`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/submitted`
       )
     )
   }

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -119,8 +119,14 @@ export const submitGetController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -136,6 +142,7 @@ export const submitGetController = {
         year,
         cadence,
         period,
+        submissionNumber,
         session.idToken
       )
     ])
@@ -147,7 +154,7 @@ export const submitGetController = {
     if (status.currentStatus === SUBMISSION_STATUS.SUBMITTED) {
       return h.redirect(
         request.localiseUrl(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submitted`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/submitted`
         )
       )
     }
@@ -162,6 +169,7 @@ export const submitGetController = {
       year,
       cadence,
       period,
+      submissionNumber,
       localise,
       localiseUrl: (url) => request.localiseUrl(url)
     })
@@ -228,6 +236,7 @@ const buildRecyclingActivityViewData = (recyclingActivity) => ({
  *   year: number,
  *   cadence: CadenceValue,
  *   period: number,
+ *   submissionNumber: number,
  *   localise: import('./helpers/format-period-label.js').Localise,
  *   localiseUrl: (url: string) => string
  * }} params
@@ -243,6 +252,7 @@ function buildViewData({
   year,
   cadence,
   period,
+  submissionNumber,
   localise,
   localiseUrl
 }) {
@@ -328,7 +338,9 @@ function buildViewData({
     // Form
     version: reportDetail.version,
 
-    deleteUrl: localiseUrl(`${reportsUrl}/${year}/${cadence}/${period}/delete`)
+    deleteUrl: localiseUrl(
+      `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/delete`
+    )
   }
 }
 
@@ -348,8 +360,14 @@ export const submitPostController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const { version } = request.payload
     const session = request.auth.credentials
 
@@ -361,13 +379,14 @@ export const submitPostController = {
       year,
       cadence,
       period,
+      submissionNumber,
       transition,
       session.idToken
     )
 
     return h.redirect(
       request.localiseUrl(
-        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submitted`
+        `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/submitted`
       )
     )
   }

--- a/src/server/reports/submit-controller.js
+++ b/src/server/reports/submit-controller.js
@@ -374,12 +374,14 @@ export const submitPostController = {
     const transition = { status: SUBMISSION_STATUS.SUBMITTED, version }
 
     await updateReportStatus(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       transition,
       session.idToken
     )

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -1347,12 +1347,14 @@ describe('#submitController', () => {
         })
 
         expect(updateReportStatus).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'quarterly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'quarterly',
+            period: 1,
+            submissionNumber: 1
+          },
           { status: 'submitted', version: 1 },
           'mock-id-token'
         )

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -306,9 +306,9 @@ const accreditedExporterReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submit`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/submit`
 const reportsUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
-const submittedUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submitted`
+const submittedUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/submitted`
 
 /** Inject a GET request and return the parsed DOM body. */
 async function getBody(server) {
@@ -1256,7 +1256,7 @@ describe('#submitController', () => {
           )
           vi.mocked(fetchReportDetail).mockResolvedValue(report)
 
-          const url = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/submit`
+          const url = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/1/submit`
           const { result } = await server.inject({
             method: 'GET',
             url,
@@ -1268,7 +1268,7 @@ describe('#submitController', () => {
           })
 
           expect(deleteButton.getAttribute('href')).toBe(
-            `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/delete`
+            `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/1/delete`
           )
           expect(deleteButton.classList.contains('govuk-button--warning')).toBe(
             true
@@ -1352,6 +1352,7 @@ describe('#submitController', () => {
           2026,
           'quarterly',
           1,
+          1,
           { status: 'submitted', version: 1 },
           'mock-id-token'
         )
@@ -1380,7 +1381,7 @@ describe('#submitController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1392,7 +1393,7 @@ describe('#submitController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1404,7 +1405,7 @@ describe('#submitController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/submit-controller.test.js
+++ b/src/server/reports/submit-controller.test.js
@@ -306,9 +306,9 @@ const accreditedExporterReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/submit`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/submit`
 const reportsUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
-const submittedUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/submitted`
+const submittedUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/submitted`
 
 /** Inject a GET request and return the parsed DOM body. */
 async function getBody(server) {
@@ -1256,7 +1256,7 @@ describe('#submitController', () => {
           )
           vi.mocked(fetchReportDetail).mockResolvedValue(report)
 
-          const url = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/1/submit`
+          const url = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/submissions/1/submit`
           const { result } = await server.inject({
             method: 'GET',
             url,
@@ -1268,7 +1268,7 @@ describe('#submitController', () => {
           })
 
           expect(deleteButton.getAttribute('href')).toBe(
-            `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/1/delete`
+            `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/${cadence}/${period}/submissions/1/delete`
           )
           expect(deleteButton.classList.contains('govuk-button--warning')).toBe(
             true
@@ -1383,7 +1383,7 @@ describe('#submitController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1395,7 +1395,7 @@ describe('#submitController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -1407,7 +1407,7 @@ describe('#submitController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/submit`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/submit`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/submitted-controller.js
+++ b/src/server/reports/submitted-controller.js
@@ -75,7 +75,7 @@ export const submittedController = {
       viewReportLink: {
         text: localise('reports:submittedViewReport'),
         href: request.localiseUrl(
-          `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/view`
+          `${reportsUrl}/${year}/${cadence}/${period}/submissions/${submissionNumber}/view`
         )
       }
     })

--- a/src/server/reports/submitted-controller.js
+++ b/src/server/reports/submitted-controller.js
@@ -19,8 +19,14 @@ export const submittedController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -38,6 +44,7 @@ export const submittedController = {
         year,
         cadence,
         period,
+        submissionNumber,
         session.idToken
       )
     ])
@@ -68,7 +75,7 @@ export const submittedController = {
       viewReportLink: {
         text: localise('reports:submittedViewReport'),
         href: request.localiseUrl(
-          `${reportsUrl}/${year}/${cadence}/${period}/view`
+          `${reportsUrl}/${year}/${cadence}/${period}/${submissionNumber}/view`
         )
       }
     })

--- a/src/server/reports/submitted-controller.test.js
+++ b/src/server/reports/submitted-controller.test.js
@@ -61,7 +61,7 @@ const mockReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
+const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1`
 const submittedUrl = `${basePeriodPath}/submitted`
 const reportsUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
@@ -307,7 +307,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/submitted`,
         auth: mockAuth
       })
 
@@ -317,7 +317,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/submitted`,
         auth: mockAuth
       })
 
@@ -327,7 +327,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid period', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/submitted`,
         auth: mockAuth
       })
 

--- a/src/server/reports/submitted-controller.test.js
+++ b/src/server/reports/submitted-controller.test.js
@@ -61,7 +61,7 @@ const mockReportDetail = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1`
+const basePeriodPath = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
 const submittedUrl = `${basePeriodPath}/submitted`
 const reportsUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports`
 
@@ -307,7 +307,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/submitted`,
         auth: mockAuth
       })
 
@@ -317,7 +317,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid year', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/submitted`,
         auth: mockAuth
       })
 
@@ -327,7 +327,7 @@ describe('#submittedController', () => {
     it('should return 400 for invalid period', async ({ server }) => {
       const { statusCode } = await server.inject({
         method: 'GET',
-        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submitted`,
+        url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/submitted`,
         auth: mockAuth
       })
 

--- a/src/server/reports/summary-log-changed-error-controller.js
+++ b/src/server/reports/summary-log-changed-error-controller.js
@@ -27,7 +27,7 @@ export const summaryLogChangedErrorGetController = {
       `/organisations/${organisationId}/registrations/${registrationId}/reports`
     )
 
-    const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+    const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
     if (request.yar.get('summaryLogChangedError') !== periodBase) {
       return h.redirect(reportsUrl)

--- a/src/server/reports/summary-log-changed-error-controller.js
+++ b/src/server/reports/summary-log-changed-error-controller.js
@@ -14,14 +14,20 @@ export const summaryLogChangedErrorGetController = {
    */
   async handler(request, h) {
     const { t: localise } = request
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
 
     const reportsUrl = request.localiseUrl(
       `/organisations/${organisationId}/registrations/${registrationId}/reports`
     )
 
-    const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+    const periodBase = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
     if (request.yar.get('summaryLogChangedError') !== periodBase) {
       return h.redirect(reportsUrl)
@@ -51,8 +57,14 @@ export const summaryLogChangedErrorPostController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
 
     await deleteReport(
@@ -61,6 +73,7 @@ export const summaryLogChangedErrorPostController = {
       year,
       cadence,
       period,
+      submissionNumber,
       session.idToken
     )
 

--- a/src/server/reports/summary-log-changed-error-controller.test.js
+++ b/src/server/reports/summary-log-changed-error-controller.test.js
@@ -23,8 +23,8 @@ const mockAuth = buildMockAuth()
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/summary-log-changed-error`
-const periodUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/summary-log-changed-error`
+const periodUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1`
 
 /**
  * Trigger the onPreResponse redirect to the error page, returning the

--- a/src/server/reports/summary-log-changed-error-controller.test.js
+++ b/src/server/reports/summary-log-changed-error-controller.test.js
@@ -23,8 +23,8 @@ const mockAuth = buildMockAuth()
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/summary-log-changed-error`
-const periodUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/summary-log-changed-error`
+const periodUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1`
 
 /**
  * Trigger the onPreResponse redirect to the error page, returning the
@@ -212,6 +212,7 @@ describe('#summaryLogChangedErrorController', () => {
         registrationId,
         2026,
         'quarterly',
+        1,
         1,
         'mock-id-token'
       )

--- a/src/server/reports/supporting-information-controller.js
+++ b/src/server/reports/supporting-information-controller.js
@@ -68,8 +68,14 @@ function getBackPage(basePath, registration, accreditation) {
  * @param {object} [options.errorSummary] - Error summary for govukErrorSummary
  */
 async function buildViewData(request, options = {}) {
-  const { organisationId, registrationId, year, cadence, period } =
-    request.params
+  const {
+    organisationId,
+    registrationId,
+    year,
+    cadence,
+    period,
+    submissionNumber
+  } = request.params
   const session = request.auth.credentials
   const { t: localise } = request
 
@@ -86,13 +92,14 @@ async function buildViewData(request, options = {}) {
     year,
     cadence,
     period,
+    submissionNumber,
     session.idToken
   )
 
   const material = getDisplayMaterial(registration)
   const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
 
-  const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+  const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
 
   const backPage = getBackPage(basePath, registration, accreditation)
 
@@ -105,7 +112,7 @@ async function buildViewData(request, options = {}) {
     heading: localise('reports:supportingInformationHeading'),
     backUrl: request.localiseUrl(backPage),
     deleteUrl: request.localiseUrl(
-      `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/delete`
+      `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/delete`
     ),
     maxLength: MAX_SUPPORTING_INFO_LENGTH,
     value: options.value ?? reportDetail.supportingInformation ?? '',
@@ -165,8 +172,14 @@ export const supportingInformationPostController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const { supportingInformation, action } = request.payload
 
     await updateReport(
@@ -175,6 +188,7 @@ export const supportingInformationPostController = {
       year,
       cadence,
       period,
+      submissionNumber,
       { supportingInformation },
       request.auth.credentials.idToken
     )
@@ -184,7 +198,7 @@ export const supportingInformationPostController = {
     if (action === 'continue') {
       return h.redirect(
         request.localiseUrl(
-          `${basePath}/${year}/${cadence}/${period}/check-your-answers`
+          `${basePath}/${year}/${cadence}/${period}/${submissionNumber}/check-your-answers`
         )
       )
     }

--- a/src/server/reports/supporting-information-controller.js
+++ b/src/server/reports/supporting-information-controller.js
@@ -183,12 +183,14 @@ export const supportingInformationPostController = {
     const { supportingInformation, action } = request.payload
 
     await updateReport(
-      organisationId,
-      registrationId,
-      year,
-      cadence,
-      period,
-      submissionNumber,
+      {
+        organisationId,
+        registrationId,
+        year,
+        cadence,
+        period,
+        submissionNumber
+      },
       { supportingInformation },
       request.auth.credentials.idToken
     )

--- a/src/server/reports/supporting-information-controller.js
+++ b/src/server/reports/supporting-information-controller.js
@@ -99,7 +99,7 @@ async function buildViewData(request, options = {}) {
   const material = getDisplayMaterial(registration)
   const periodLabel = formatPeriodLabel({ year, period }, cadence, localise)
 
-  const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`
+  const basePath = `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
 
   const backPage = getBackPage(basePath, registration, accreditation)
 
@@ -112,7 +112,7 @@ async function buildViewData(request, options = {}) {
     heading: localise('reports:supportingInformationHeading'),
     backUrl: request.localiseUrl(backPage),
     deleteUrl: request.localiseUrl(
-      `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/delete`
+      `/organisations/${organisationId}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/delete`
     ),
     maxLength: MAX_SUPPORTING_INFO_LENGTH,
     value: options.value ?? reportDetail.supportingInformation ?? '',
@@ -200,7 +200,7 @@ export const supportingInformationPostController = {
     if (action === 'continue') {
       return h.redirect(
         request.localiseUrl(
-          `${basePath}/${year}/${cadence}/${period}/${submissionNumber}/check-your-answers`
+          `${basePath}/${year}/${cadence}/${period}/submissions/${submissionNumber}/check-your-answers`
         )
       )
     }

--- a/src/server/reports/supporting-information-controller.test.js
+++ b/src/server/reports/supporting-information-controller.test.js
@@ -89,7 +89,7 @@ const reportDetailWithSupportingInfo = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
 
 describe('#supportingInformationController', () => {
   beforeEach(() => {
@@ -255,7 +255,7 @@ describe('#supportingInformationController', () => {
         expect(deleteLink).not.toBeNull()
         expect(deleteLink?.textContent).toContain('Delete report')
         expect(deleteLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/delete`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
         )
       })
 
@@ -275,7 +275,7 @@ describe('#supportingInformationController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-not-exported`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-exported`
         )
       })
 
@@ -290,7 +290,7 @@ describe('#supportingInformationController', () => {
           }
         })
 
-        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/supporting-information`
+        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -304,7 +304,7 @@ describe('#supportingInformationController', () => {
         const backLink = body.querySelector('.govuk-back-link')
 
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/free-prns`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/free-prns`
         )
       })
 
@@ -319,7 +319,7 @@ describe('#supportingInformationController', () => {
           }
         })
 
-        const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/supporting-information`
+        const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -333,7 +333,7 @@ describe('#supportingInformationController', () => {
         const backLink = body.querySelector('.govuk-back-link')
 
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
         )
       })
 
@@ -344,7 +344,7 @@ describe('#supportingInformationController', () => {
           accreditedExporter
         )
 
-        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/supporting-information`
+        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -359,7 +359,7 @@ describe('#supportingInformationController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/free-perns`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/free-perns`
         )
       })
     })
@@ -441,7 +441,7 @@ describe('#supportingInformationController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/check-your-answers`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/check-your-answers`
         )
       })
 
@@ -469,6 +469,7 @@ describe('#supportingInformationController', () => {
           registrationId,
           2026,
           'quarterly',
+          1,
           1,
           { supportingInformation: 'Notes for regulator' },
           'mock-id-token'
@@ -499,6 +500,7 @@ describe('#supportingInformationController', () => {
           registrationId,
           2026,
           'quarterly',
+          1,
           1,
           { supportingInformation: '' },
           'mock-id-token'
@@ -556,6 +558,7 @@ describe('#supportingInformationController', () => {
           registrationId,
           2026,
           'quarterly',
+          1,
           1,
           { supportingInformation: 'Partial notes' },
           'mock-id-token'
@@ -694,7 +697,7 @@ describe('#supportingInformationController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -706,7 +709,7 @@ describe('#supportingInformationController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -718,7 +721,7 @@ describe('#supportingInformationController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/supporting-information-controller.test.js
+++ b/src/server/reports/supporting-information-controller.test.js
@@ -89,7 +89,7 @@ const reportDetailWithSupportingInfo = {
 
 const organisationId = 'org-123'
 const registrationId = 'reg-001'
-const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+const baseUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
 
 describe('#supportingInformationController', () => {
   beforeEach(() => {
@@ -255,7 +255,7 @@ describe('#supportingInformationController', () => {
         expect(deleteLink).not.toBeNull()
         expect(deleteLink?.textContent).toContain('Delete report')
         expect(deleteLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/delete`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/delete`
         )
       })
 
@@ -275,7 +275,7 @@ describe('#supportingInformationController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-exported`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-not-exported`
         )
       })
 
@@ -290,7 +290,7 @@ describe('#supportingInformationController', () => {
           }
         })
 
-        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
+        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -304,7 +304,7 @@ describe('#supportingInformationController', () => {
         const backLink = body.querySelector('.govuk-back-link')
 
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/free-prns`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/free-prns`
         )
       })
 
@@ -319,7 +319,7 @@ describe('#supportingInformationController', () => {
           }
         })
 
-        const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/supporting-information`
+        const quarterlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -333,7 +333,7 @@ describe('#supportingInformationController', () => {
         const backLink = body.querySelector('.govuk-back-link')
 
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/tonnes-not-recycled`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/tonnes-not-recycled`
         )
       })
 
@@ -344,7 +344,7 @@ describe('#supportingInformationController', () => {
           accreditedExporter
         )
 
-        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/supporting-information`
+        const monthlyUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/supporting-information`
 
         const { result } = await server.inject({
           method: 'GET',
@@ -359,7 +359,7 @@ describe('#supportingInformationController', () => {
 
         expect(backLink).not.toBeNull()
         expect(backLink?.getAttribute('href')).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/free-perns`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/free-perns`
         )
       })
     })
@@ -441,7 +441,7 @@ describe('#supportingInformationController', () => {
 
         expect(statusCode).toBe(statusCodes.found)
         expect(headers.location).toBe(
-          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/1/check-your-answers`
+          `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/1/submissions/1/check-your-answers`
         )
       })
 
@@ -703,7 +703,7 @@ describe('#supportingInformationController', () => {
 
   describe('param validation', () => {
     it('should return 400 for invalid cadence', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/1/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/invalid/1/submissions/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -715,7 +715,7 @@ describe('#supportingInformationController', () => {
     })
 
     it('should return 400 for invalid year', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/1/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2023/quarterly/1/submissions/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',
@@ -727,7 +727,7 @@ describe('#supportingInformationController', () => {
     })
 
     it('should return 400 for invalid period', async ({ server }) => {
-      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/1/supporting-information`
+      const invalidUrl = `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/quarterly/13/submissions/1/supporting-information`
 
       const { statusCode } = await server.inject({
         method: 'GET',

--- a/src/server/reports/supporting-information-controller.test.js
+++ b/src/server/reports/supporting-information-controller.test.js
@@ -465,12 +465,14 @@ describe('#supportingInformationController', () => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'quarterly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'quarterly',
+            period: 1,
+            submissionNumber: 1
+          },
           { supportingInformation: 'Notes for regulator' },
           'mock-id-token'
         )
@@ -496,12 +498,14 @@ describe('#supportingInformationController', () => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'quarterly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'quarterly',
+            period: 1,
+            submissionNumber: 1
+          },
           { supportingInformation: '' },
           'mock-id-token'
         )
@@ -554,12 +558,14 @@ describe('#supportingInformationController', () => {
         })
 
         expect(updateReport).toHaveBeenCalledWith(
-          organisationId,
-          registrationId,
-          2026,
-          'quarterly',
-          1,
-          1,
+          {
+            organisationId,
+            registrationId,
+            year: 2026,
+            cadence: 'quarterly',
+            period: 1,
+            submissionNumber: 1
+          },
           { supportingInformation: 'Partial notes' },
           'mock-id-token'
         )

--- a/src/server/reports/view-controller.js
+++ b/src/server/reports/view-controller.js
@@ -233,8 +233,14 @@ export const viewGetController = {
    * @param {ResponseToolkit} h
    */
   async handler(request, h) {
-    const { organisationId, registrationId, year, cadence, period } =
-      request.params
+    const {
+      organisationId,
+      registrationId,
+      year,
+      cadence,
+      period,
+      submissionNumber
+    } = request.params
     const session = request.auth.credentials
     const { t: localise } = request
 
@@ -250,6 +256,7 @@ export const viewGetController = {
         year,
         cadence,
         period,
+        submissionNumber,
         session.idToken
       )
     ])

--- a/src/server/reports/view-controller.test.js
+++ b/src/server/reports/view-controller.test.js
@@ -27,7 +27,7 @@ async function loadPage({ server, registrationAndAccreditation }) {
   const registrationId = registrationAndAccreditation.registration?.id
   return await server.inject({
     method: 'GET',
-    url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/view`,
+    url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/submissions/1/view`,
     auth: mockAuth
   })
 }

--- a/src/server/reports/view-controller.test.js
+++ b/src/server/reports/view-controller.test.js
@@ -27,7 +27,7 @@ async function loadPage({ server, registrationAndAccreditation }) {
   const registrationId = registrationAndAccreditation.registration?.id
   return await server.inject({
     method: 'GET',
-    url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/view`,
+    url: `/organisations/${organisationId}/registrations/${registrationId}/reports/2026/monthly/1/1/view`,
     auth: mockAuth
   })
 }


### PR DESCRIPTION
Ticket: [PAE-1554](https://eaflood.atlassian.net/browse/PAE-1554)
- Thread submissionNumber through all report-related API calls, page helpers, and route params
- Update period-params schema and URL construction to include submissionNumber

**Not fixing the test type check errors, as its all existing one's and bit of an effort to fix part of this PR**

[PAE-1554]: https://eaflood.atlassian.net/browse/PAE-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ