### PR TITLE
PAE-250: Fix joi vulnerability path via cdp-auditing bump

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,5 +4,5 @@ ignore:
   'SNYK-JS-POSTCSSSELECTORPARSER-16873882':
     - '*':
         reason: 'No upstream fix available. postcss-selector-parser is pulled in transitively by cssnano during the webpack CSS build only and is never reached at application runtime, so the uncontrolled-recursion DoS is not exploitable here. Revisit when a patched version is published.'
-        expires: '2026-11-27T00:00:00.000Z'
+        expires: '2027-06-12T00:00:00.000Z'
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/cdp-auditing": "0.6.0",
+        "@defra/cdp-auditing": "0.6.1",
         "@defra/cdp-metrics": "0.5.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
@@ -2148,53 +2148,16 @@
       "license": "MIT"
     },
     "node_modules/@defra/cdp-auditing": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.0.tgz",
-      "integrity": "sha512-CVysJOutZ3CLn8McdMxA0hIs+XgoaHOOwRQGmMt7BZU2SGSbjfdb/T+pLVg1SZk1XsIK6VQ7cufIc6t7L3T2XQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@defra/cdp-auditing/-/cdp-auditing-0.6.1.tgz",
+      "integrity": "sha512-KJiKDTpAqolaxbm/8D345kKeZeK2uqDxhD7QOAI9sd7hEQzy9qj4pcAZSh0Xo6/7VNi6AuN0Y+jllTZZBPcIyA==",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "18.0.2",
         "pino": "10.1.0"
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@defra/cdp-auditing/node_modules/@hapi/address": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@defra/cdp-auditing/node_modules/@hapi/formula": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@defra/cdp-auditing/node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@defra/cdp-auditing/node_modules/pino": {
@@ -2930,15 +2893,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.1.tgz",
       "integrity": "sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/tlds": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-      "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
@@ -5867,6 +5821,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/core": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/cdp-auditing": "0.6.0",
+    "@defra/cdp-auditing": "0.6.1",
     "@defra/cdp-metrics": "0.5.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Fixes a joi advisory path flagged by the dependency audit.

- Bumps `@defra/cdp-auditing` to 0.6.1, which drops its `joi` dependency entirely and removes the joi 18.x path that surfaced GHSA-q7cg-457f-vx79.

The `postcss-selector-parser` Snyk ignore was confirmed still needed (no upstream fix; reachable only during the CSS build) and its expiry refreshed. The existing `uuid` override was checked and confirmed still needed.

A `joi` advisory (GHSA-q7cg-457f-vx79, moderate DoS) remains via hapi packages (`@hapi/bell`, `@hapi/catbox-redis`, `hapi-pulse`) that pin joi 17.x with no fixed 17.x release published; clearing it would require a coordinated joi 17→18 major upgrade, tracked separately. The `@hapi/inert` and `@hapi/wreck` advisories were already resolved on main by a merged security PR.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ