### PR TITLE
PAE-1541: require processing-type on a validated summary log

### DIFF
--- a/src/domain/summary-logs/meta-fields.js
+++ b/src/domain/summary-logs/meta-fields.js
@@ -13,22 +13,19 @@ export const PROCESSING_TYPES = Object.freeze({
 
 /** @typedef {typeof PROCESSING_TYPES[keyof typeof PROCESSING_TYPES]} ProcessingType */
 
-export const REGISTERED_ONLY_PROCESSING_TYPES = new Set([
+/** @typedef {'EXPORTER_REGISTERED_ONLY' | 'REPROCESSOR_REGISTERED_ONLY'} RegisteredOnlyProcessingType */
+
+/** @type {ReadonlySet<string>} */
+const REGISTERED_ONLY_PROCESSING_TYPES = new Set([
   PROCESSING_TYPES.EXPORTER_REGISTERED_ONLY,
   PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY
 ])
 
-/** @typedef {'EXPORTER_REGISTERED_ONLY' | 'REPROCESSOR_REGISTERED_ONLY'} RegisteredOnlyProcessingType */
-
 /**
  * Whether a processing type is registered-only (no accreditation, so the check
- * page shows totals only rather than waste balance language). Accepts a widened
- * input so callers holding an optional or loosely-typed processingType need no
- * cast at the call site.
- * @param {ProcessingType | string | undefined} processingType
+ * page shows totals only rather than waste balance language).
+ * @param {ProcessingType} processingType
  * @returns {processingType is RegisteredOnlyProcessingType}
  */
 export const isRegisteredOnlyProcessingType = (processingType) =>
-  REGISTERED_ONLY_PROCESSING_TYPES.has(
-    /** @type {RegisteredOnlyProcessingType} */ (processingType)
-  )
+  REGISTERED_ONLY_PROCESSING_TYPES.has(processingType)

--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -112,15 +112,13 @@ const REUPLOAD_STATES = new Set([
 ])
 
 /**
- * Gets the waste record section number to display in UI copy based on processing type
- * @param {ProcessingType} [processingType] - Processing type from summary log meta
+ * Gets the waste record section number to display in UI copy based on processing
+ * type. Registered-only types are not in the section map and return undefined.
+ * @param {ProcessingType} processingType - Processing type from summary log meta
  * @returns {number | undefined} Waste record section number (1 or 3)
  */
-export const getWasteRecordSectionNumber = (processingType) => {
-  return processingType === undefined
-    ? undefined
-    : WASTE_RECORD_SECTION_BY_PROCESSING_TYPE[processingType]
-}
+export const getWasteRecordSectionNumber = (processingType) =>
+  WASTE_RECORD_SECTION_BY_PROCESSING_TYPE[processingType]
 
 const VIEW_NAME = 'summary-log/progress'
 const CHECK_VIEW_NAME = 'summary-log/check'

--- a/src/server/summary-log/controller.js
+++ b/src/server/summary-log/controller.js
@@ -53,6 +53,13 @@ import { buildValidationFailuresViewModel } from './validation-failures-view-mod
  * }} RenderContext
  */
 
+/**
+ * A validated summary log's render context. The backend guarantees a processing
+ * type on every validated response, so it is required here, narrowed at the
+ * render boundary by toValidatedContext.
+ * @typedef {RenderContext & { processingType: ProcessingType }} ValidatedRenderContext
+ */
+
 const SECTION_BY_PROCESSING_TYPE_AND_WASTE_RECORD_TYPE = Object.freeze({
   [PROCESSING_TYPES.REPROCESSOR_REGISTERED_ONLY]: Object.freeze({
     [WASTE_RECORD_TYPE.RECEIVED]:
@@ -297,7 +304,7 @@ const getStatusData = async (
  * misleading empty page.
  * @param {ResponseToolkit} h - Hapi response toolkit
  * @param {(key: string) => string} localise - i18n localisation function
- * @param {RenderContext} context - View context
+ * @param {ValidatedRenderContext} context - View context
  * @returns {ResponseObject} Hapi view response
  */
 const renderCheckView = (h, localise, context) => {
@@ -455,7 +462,6 @@ const renderProgressView = (h, localise, { status, pollUrl }) => {
  * ) => ResponseObject>}
  */
 const viewResolvers = {
-  [summaryLogStatuses.validated]: renderCheckView,
   [summaryLogStatuses.submitting]: renderSubmittingView,
   [summaryLogStatuses.submitted]: renderSuccessView,
   [summaryLogStatuses.superseded]: renderSupersededView,
@@ -463,6 +469,22 @@ const viewResolvers = {
   [summaryLogStatuses.rejected]: renderValidationFailuresView,
   [summaryLogStatuses.validationFailed]: renderValidationFailuresView,
   [summaryLogStatuses.submissionFailed]: renderValidationFailuresView
+}
+
+/**
+ * Narrows a render context for a validated summary log. The backend guarantees
+ * a processingType on every validated response, so a missing one is a contract
+ * violation we fail loudly on here, at the boundary, rather than letting the
+ * render paths treat the operator as accredited.
+ * @param {RenderContext} context
+ * @returns {ValidatedRenderContext}
+ */
+const toValidatedContext = (context) => {
+  if (context.processingType === undefined) {
+    throw new Error('Expected processingType for validated summary log')
+  }
+
+  return { ...context, processingType: context.processingType }
 }
 
 /**
@@ -475,6 +497,11 @@ const viewResolvers = {
  */
 const renderViewForStatus = (options) => {
   const { h, localise, status } = options
+
+  if (status === summaryLogStatuses.validated) {
+    return renderCheckView(h, localise, toValidatedContext(options))
+  }
+
   const resolver = viewResolvers[status] ?? renderProgressView
 
   return resolver(h, localise, options)

--- a/src/server/summary-log/controller.test.js
+++ b/src/server/summary-log/controller.test.js
@@ -254,7 +254,8 @@ describe('#summaryLogUploadProgressController', () => {
       server
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
-        status: summaryLogStatuses.validated
+        status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER'
       })
 
       const { result, statusCode } = await server.inject({
@@ -283,7 +284,8 @@ describe('#summaryLogUploadProgressController', () => {
       server
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
-        status: summaryLogStatuses.validated
+        status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER'
       })
 
       const { result, statusCode } = await server.inject({
@@ -303,7 +305,8 @@ describe('#summaryLogUploadProgressController', () => {
       server
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
-        status: summaryLogStatuses.validated
+        status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER'
       })
 
       const { result, statusCode } = await server.inject({
@@ -431,6 +434,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: {
@@ -473,6 +477,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -544,6 +549,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 3, rowIds: ['1092', '1093', '1094'] },
@@ -580,6 +586,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 1, rowIds: ['1092'] },
@@ -620,6 +627,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: {
@@ -663,6 +671,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -698,6 +707,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -733,6 +743,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -769,6 +780,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -802,6 +814,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: { count: 0, rowIds: [] },
@@ -845,6 +858,7 @@ describe('#summaryLogUploadProgressController', () => {
     }) => {
       mockFetchSummaryLogStatus.mockResolvedValueOnce({
         status: summaryLogStatuses.validated,
+        processingType: 'EXPORTER',
         loads: {
           added: {
             included: {
@@ -926,6 +940,7 @@ describe('#summaryLogUploadProgressController', () => {
       }) => {
         mockFetchSummaryLogStatus.mockResolvedValueOnce({
           status: summaryLogStatuses.validated,
+          processingType: 'EXPORTER',
           loads: {
             added: {
               included: { count: 0, rowIds: [] },
@@ -3731,6 +3746,32 @@ describe('enhanced summary log check view', () => {
     mockFetchSummaryLogStatus.mockResolvedValueOnce({
       status: summaryLogStatuses.validated,
       processingType: 'EXPORTER'
+    })
+
+    const { result, statusCode } = await server.inject({
+      method: 'GET',
+      url,
+      auth: mockAuth
+    })
+
+    expect(statusCode).toBe(statusCodes.internalServerError)
+    expect(result).toStrictEqual(
+      expect.stringContaining('Something went wrong')
+    )
+  })
+
+  it('returns a 500 when a validated response is missing processingType', async ({
+    server
+  }) => {
+    // The backend requires processingType on every validated response, so a
+    // missing one is a contract violation: fail loudly at the boundary rather
+    // than render the page as though the operator were accredited.
+    mockFetchSummaryLogStatus.mockResolvedValueOnce({
+      status: summaryLogStatuses.validated,
+      loadsByReportingPeriod: {
+        openPeriodLoads: emptyPeriod(),
+        closedPeriodLoads: emptyPeriod()
+      }
     })
 
     const { result, statusCode } = await server.inject({

--- a/src/server/summary-log/controller.test.js
+++ b/src/server/summary-log/controller.test.js
@@ -3105,10 +3105,6 @@ describe('#getWasteRecordSectionNumber', () => {
     expect(getWasteRecordSectionNumber('EXPORTER')).toBe(1)
   })
 
-  test('returns undefined for undefined processingType', () => {
-    expect(getWasteRecordSectionNumber(undefined)).toBeUndefined()
-  })
-
   test('returns undefined for unknown processingType', () => {
     expect(
       getWasteRecordSectionNumber(

--- a/src/server/summary-log/enhanced-check-controller.js
+++ b/src/server/summary-log/enhanced-check-controller.js
@@ -3,6 +3,7 @@ import { isRegisteredOnlyProcessingType } from '#domain/summary-logs/meta-fields
 
 /**
  * @import { ResponseObject, ResponseToolkit } from '@hapi/hapi'
+ * @import { ProcessingType } from '#domain/summary-logs/meta-fields.js'
  * @import {
  *   ChangeViewModel,
  *   LoadsByReportingPeriod,
@@ -117,7 +118,7 @@ const buildPeriodViewModel = (period) => {
  * @param {(key: string, params?: object) => string} localise - i18n localisation function
  * @param {{
  *   loadsByReportingPeriod?: LoadsByReportingPeriod,
- *   processingType?: string,
+ *   processingType: ProcessingType,
  *   organisationId: string,
  *   registrationId: string,
  *   summaryLogId: string,


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
- backend: response schema requires processing-type when status is validated
- frontend: validated render path narrows to required processing-type, dropping undefined-handling in the predicate and render code

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ