### PR TITLE
PAE-1556 add call to add user to org on sign-in

### DIFF
--- a/src/server/auth/callback/controller.js
+++ b/src/server/auth/callback/controller.js
@@ -1,4 +1,5 @@
 import { ACCOUNT_LINKING_PATH } from '#server/account/linking/controller.js'
+import { addUserToOrganisation } from '#server/auth/helpers/add-user-to-organisation.js'
 import { fetchUserOrganisations } from '#server/auth/helpers/fetch-user-organisations.js'
 import { paths } from '#server/paths.js'
 import { auditSignIn } from '#server/common/helpers/auditing/index.js'
@@ -68,6 +69,8 @@ const controller = {
       if (!organisations.linked) {
         return h.redirect(ACCOUNT_LINKING_PATH)
       }
+
+      await addUserToOrganisation(organisations.linked.id, session.idToken)
 
       const isInitialUser =
         organisations.linked.linkedBy?.id === session.profile.id

--- a/src/server/auth/callback/controller.test.js
+++ b/src/server/auth/callback/controller.test.js
@@ -12,6 +12,7 @@ vi.mock(import('node:crypto'), () => ({
 }))
 
 vi.mock(import('#server/auth/helpers/fetch-user-organisations.js'))
+vi.mock(import('#server/auth/helpers/add-user-to-organisation.js'))
 vi.mock(import('#server/common/helpers/metrics/index.js'))
 
 describe('#authCallbackController', () => {

--- a/src/server/auth/callback/get.integration.test.js
+++ b/src/server/auth/callback/get.integration.test.js
@@ -95,7 +95,7 @@ describe('/auth/callback - GET integration', async () => {
     email: 'user@email.com'
   })
 
-  describe('on successful return from Defra ID', () => {
+  describe('on successful return from Defra ID - unlinked organisation', () => {
     beforeEach(({ msw }) => {
       const backendUrl = config.get('eprBackendUrl')
       msw.use(
@@ -119,6 +119,90 @@ describe('/auth/callback - GET integration', async () => {
 
       expect(response.statusCode).toBe(statusCodes.found)
       expect(response.headers['location']).toBe('/account/linking')
+    })
+
+    it('records sign in success metric', async ({ server, msw }) => {
+      await performSignInFlow(server, msw, idTokenAndPublicKey)
+
+      expect(mock.signInSuccessMetric).toHaveBeenCalledTimes(1)
+    })
+
+    it('audits a successful sign in attempt', async ({ server, msw }) => {
+      await performSignInFlow(server, msw, idTokenAndPublicKey)
+
+      expect(mock.cdpAuditing).toHaveBeenCalledTimes(1)
+      expect(mock.cdpAuditing).toHaveBeenCalledWith({
+        event: {
+          category: 'access',
+          action: 'sign-in'
+        },
+        context: {},
+        user: {
+          id: 'user-id',
+          email: 'user@email.com'
+        }
+      })
+    })
+  })
+
+  describe('on successful return from Defra ID - linked organisation', () => {
+    const userOrganisationsResponse = {
+      organisations: {
+        current: { id: 'organisation-id', name: 'company-name' },
+        linked: {
+          id: 'linked-org-id',
+          name: 'Linked Company',
+          linkedBy: { id: 'user-id', email: 'user@email.com' },
+          linkedAt: '2025-01-01T00:00:00.000Z'
+        },
+        unlinked: []
+      }
+    }
+
+    beforeEach(({ msw }) => {
+      const backendUrl = config.get('eprBackendUrl')
+
+      msw.use(
+        http.get(`${backendUrl}/v1/me/organisations`, () => {
+          return HttpResponse.json(userOrganisationsResponse)
+        }),
+        http.put(
+          `${backendUrl}/v1/organisations/:organisationId/user`,
+          () => new HttpResponse(null, { status: 200 })
+        )
+      )
+    })
+
+    it('redirects to organisation dashboard', async ({ server, msw }) => {
+      const response = await performSignInFlow(server, msw, idTokenAndPublicKey)
+
+      expect(response.statusCode).toBe(statusCodes.found)
+      expect(response.headers['location']).toBe('/organisations/linked-org-id')
+    })
+
+    it('calls add user to organisation API with the linked organisation id', async ({
+      server,
+      msw
+    }) => {
+      const backendUrl = config.get('eprBackendUrl')
+      let capturedOrganisationId
+
+      msw.use(
+        http.get(`${backendUrl}/v1/me/organisations`, () => {
+          return HttpResponse.json(userOrganisationsResponse)
+        }),
+        http.put(
+          `${backendUrl}/v1/organisations/:organisationId/user`,
+          ({ params }) => {
+            capturedOrganisationId = params.organisationId
+            return new HttpResponse(null, { status: 200 })
+          }
+        )
+      )
+
+      await performSignInFlow(server, msw, idTokenAndPublicKey)
+
+      expect(capturedOrganisationId).toBe('linked-org-id')
     })
 
     it('records sign in success metric', async ({ server, msw }) => {
@@ -209,7 +293,11 @@ describe('/auth/callback - GET integration', async () => {
               unlinked: []
             }
           })
-        })
+        }),
+        http.put(
+          `${backendUrl}/v1/organisations/:organisationId/user`,
+          () => new HttpResponse(null, { status: 200 })
+        )
       )
 
       const invitedUserToken = await generateIdToken({
@@ -241,7 +329,11 @@ describe('/auth/callback - GET integration', async () => {
               unlinked: []
             }
           })
-        })
+        }),
+        http.put(
+          `${backendUrl}/v1/organisations/:organisationId/user`,
+          () => new HttpResponse(null, { status: 200 })
+        )
       )
 
       const linkerToken = await generateIdToken({

--- a/src/server/auth/callback/get.integration.test.js
+++ b/src/server/auth/callback/get.integration.test.js
@@ -68,23 +68,20 @@ const performSignInFlow = async (server, mswServer, { idToken, publicKey }) => {
   })
 }
 
-async function generateIdToken(payload) {
-  const { privateKey, publicKey } = generateKeyPairSync('rsa', {
-    modulusLength: 4096,
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'jwk'
-    },
-    privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem'
-    }
+async function generateIdToken(/** @type {Record<string, unknown>} */ payload) {
+  const { privateKey: privateKeyObject, publicKey: publicKeyObject } =
+    generateKeyPairSync('rsa', { modulusLength: 4096 })
+
+  const publicKey = publicKeyObject.export({ format: 'jwk' })
+  const privateKeyPem = privateKeyObject.export({
+    type: 'pkcs8',
+    format: 'pem'
   })
 
   const jwt = await new jose.SignJWT(payload)
     .setProtectedHeader({ alg: 'RS256', kid: 'test-key-id' })
     .setExpirationTime('2h')
-    .sign(createPrivateKey(privateKey))
+    .sign(createPrivateKey(privateKeyPem))
 
   return { idToken: jwt, publicKey }
 }

--- a/src/server/auth/helpers/add-user-to-organisation.js
+++ b/src/server/auth/helpers/add-user-to-organisation.js
@@ -1,0 +1,16 @@
+import { fetchJsonFromBackend } from '#server/common/helpers/fetch-json-from-backend.js'
+
+/**
+ * Adds the authenticated user to an organisation via the backend API
+ * @param {string} organisationId
+ * @param {string} idToken
+ * @returns {Promise<void>}
+ */
+export async function addUserToOrganisation(organisationId, idToken) {
+  await fetchJsonFromBackend(`/v1/organisations/${organisationId}/user`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${idToken}`
+    }
+  })
+}

--- a/src/server/auth/helpers/add-user-to-organisation.test.js
+++ b/src/server/auth/helpers/add-user-to-organisation.test.js
@@ -1,0 +1,89 @@
+import { config } from '#config/config.js'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { addUserToOrganisation } from './add-user-to-organisation.js'
+
+describe('#addUserToOrganisation', () => {
+  const backendUrl = config.get('eprBackendUrl')
+  const mockIdToken = 'mock-id-token-12345'
+  const organisationId = 'org-123'
+
+  const mockServer = setupServer(
+    http.put(
+      `${backendUrl}/v1/organisations/${organisationId}/user`,
+      ({ request }) => {
+        const authHeader = request.headers.get('Authorization')
+
+        if (authHeader === `Bearer ${mockIdToken}`) {
+          return new HttpResponse(null, { status: 200 })
+        }
+
+        return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+    )
+  )
+
+  beforeAll(() => {
+    mockServer.listen()
+  })
+
+  afterEach(() => {
+    mockServer.resetHandlers()
+  })
+
+  afterAll(() => {
+    mockServer.close()
+  })
+
+  it('should add user to organisation successfully with valid token', async () => {
+    await expect(
+      addUserToOrganisation(organisationId, mockIdToken)
+    ).resolves.not.toThrow()
+  })
+
+  it('should throw error when backend returns 401', async () => {
+    await expect(
+      addUserToOrganisation(organisationId, 'invalid-token')
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: {
+        statusCode: 401
+      }
+    })
+  })
+
+  it('should throw error when backend returns 500', async () => {
+    mockServer.use(
+      http.put(`${backendUrl}/v1/organisations/${organisationId}/user`, () =>
+        HttpResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+      )
+    )
+
+    await expect(
+      addUserToOrganisation(organisationId, mockIdToken)
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: {
+        statusCode: 500
+      }
+    })
+  })
+
+  it('should throw error when network request fails', async () => {
+    mockServer.use(
+      http.put(`${backendUrl}/v1/organisations/${organisationId}/user`, () =>
+        HttpResponse.error()
+      )
+    )
+
+    await expect(
+      addUserToOrganisation(organisationId, mockIdToken)
+    ).rejects.toMatchObject({
+      isBoom: true,
+      output: {
+        statusCode: 500
+      }
+    })
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
## Description

When a user successfully authenticates via Defra ID and has a linked organisation, the backend needs to be notified of the user's presence in that organisation.

Currently adding a user to an org happens as a side-effect when making authorisation calls to _any_ API endpoint protected by the Defra ID token - this change moves away from that and instead calls a new "add user to organisation" endpoint

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ