### PR TITLE
PAE-000: bump @defra/cdp-metrics to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@defra/cdp-auditing": "0.6.1",
-        "@defra/cdp-metrics": "0.5.0",
+        "@defra/cdp-metrics": "0.6.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -2236,9 +2236,9 @@
       }
     },
     "node_modules/@defra/cdp-metrics": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@defra/cdp-metrics/-/cdp-metrics-0.5.0.tgz",
-      "integrity": "sha512-QiqRmqQiG1ULwCp2wDUi8IfH+3xAKP/uO+di4F63VwYSls+Aqr/PWZPOjbKothVtph3Au/HMpn02QAtUacNPlA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@defra/cdp-metrics/-/cdp-metrics-0.6.0.tgz",
+      "integrity": "sha512-YwZfBXVs8DQmBW8fELaImj4OGqWKm/1vQ8CbVWbH653sPFkVl96/kCTzjlrnHMCdtyNYeHjbJpcBklrp1K9o1A==",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@defra/cdp-auditing": "0.6.1",
-    "@defra/cdp-metrics": "0.5.0",
+    "@defra/cdp-metrics": "0.6.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/server/auth/helpers/session-cookie.js
+++ b/src/server/auth/helpers/session-cookie.js
@@ -97,13 +97,11 @@ const createBlockingRefresh = (verifyToken) => {
 
   /** @type {ReturnType<typeof createBlockingRefresh>} */
   const blockingRefresh = async (request, userSession) => {
-    const refreshedSession = await request
-      .metrics()
-      .timer(
-        'tokenRefreshDuration',
-        () => refreshIdTokenAndUpdateSession(request, userSession),
-        { type: 'blocking' }
-      )
+    const refreshedSession = await request.metrics.timer(
+      'tokenRefreshDuration',
+      () => refreshIdTokenAndUpdateSession(request, userSession),
+      { type: 'blocking' }
+    )
 
     request.logger.info({
       message: 'Token refresh complete (blocking)',
@@ -131,13 +129,11 @@ const createBackgroundRefresh = (verifyToken) => {
   /** @type {ReturnType<typeof createBackgroundRefresh>} */
   const backgroundRefresh = (request, userSession) => {
     const run = async () => {
-      const refreshedSession = await request
-        .metrics()
-        .timer(
-          'tokenRefreshDuration',
-          () => refreshIdTokenAndUpdateSession(request, userSession),
-          { type: 'background' }
-        )
+      const refreshedSession = await request.metrics.timer(
+        'tokenRefreshDuration',
+        () => refreshIdTokenAndUpdateSession(request, userSession),
+        { type: 'background' }
+      )
 
       request.logger.info({
         message: 'Token refresh complete (background)',

--- a/src/server/common/hapi-types.js
+++ b/src/server/common/hapi-types.js
@@ -98,7 +98,7 @@
  *   i18n: i18n,
  *   localiseUrl: (url: string) => string,
  *   wasteOrganisationsService: WasteOrganisationsService,
- *   metrics: () => Metrics,
+ *   metrics: Metrics,
  *   cookieAuth: CookieAuth
  * }} HapiRequest
  */


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
bump @defra/cdp-metrics from 0.5.0 to 0.6.0.

- 0.6.0 decorates `request.metrics` as the `Metrics` instance directly rather than a factory function
- migrate the two `request.metrics().timer(...)` call sites in session-cookie.js to `request.metrics.timer(...)`
- update the `metrics` decoration type in hapi-types.js accordingly