### PR TITLE
PAE-1574: Rename Due status action link to 'Create draft'

### DIFF
--- a/src/server/reports/en.json
+++ b/src/server/reports/en.json
@@ -1,10 +1,10 @@
 {
   "accreditationLabel": "Accreditation",
   "actionContinue": "Continue",
+  "actionCreateDraft": "Create draft",
   "actionRequiredEmpty": "You do not currently have any reports that require an action.",
   "actionRequiredHeading": "Action required",
   "actionReviewAndSubmit": "Review and submit",
-  "actionSelect": "Select",
   "actionView": "View",
   "activityColumn": "Activity",
   "addressColumn": "Address",

--- a/src/server/reports/helpers/format-submission-status.js
+++ b/src/server/reports/helpers/format-submission-status.js
@@ -23,7 +23,7 @@ const statusLabelKeys = {
 
 /** @type {Record<SubmissionStatusValue, string>} */
 const actionLabelKeys = {
-  [SUBMISSION_STATUS.DUE]: 'reports:actionSelect',
+  [SUBMISSION_STATUS.DUE]: 'reports:actionCreateDraft',
   [SUBMISSION_STATUS.IN_PROGRESS]: 'reports:actionContinue',
   [SUBMISSION_STATUS.READY_TO_SUBMIT]: 'reports:actionReviewAndSubmit',
   [SUBMISSION_STATUS.SUBMITTED]: 'reports:actionView'

--- a/src/server/reports/helpers/format-submission-status.test.js
+++ b/src/server/reports/helpers/format-submission-status.test.js
@@ -64,8 +64,8 @@ describe('#format-submission-status', () => {
       )
     })
 
-    it('returns "Select" action for "due" status', () => {
-      expect(getActionLabel('due', localise)).toBe('reports:actionSelect')
+    it('returns "Create draft" action for "due" status', () => {
+      expect(getActionLabel('due', localise)).toBe('reports:actionCreateDraft')
     })
 
     it('returns "Review and submit" action for "ready_to_submit" status', () => {

--- a/src/server/reports/list-controller.js
+++ b/src/server/reports/list-controller.js
@@ -101,7 +101,7 @@ const buildActionCell = ({
 }) => {
   const { actionPath, actionLabel } =
     status === null
-      ? { actionPath: '', actionLabel: localise('reports:actionSelect') }
+      ? { actionPath: '', actionLabel: localise('reports:actionCreateDraft') }
       : {
           actionPath: getActionPath(
             status,

--- a/src/server/reports/list-controller.test.js
+++ b/src/server/reports/list-controller.test.js
@@ -411,7 +411,7 @@ describe('#listReportsController', () => {
       expect(table?.textContent).toContain('March 2026')
     })
 
-    it('should display Select links for accredited reprocessor periods', async ({
+    it('should display Create draft links for accredited reprocessor periods', async ({
       server
     }) => {
       const { result } = await server.inject({
@@ -429,7 +429,7 @@ describe('#listReportsController', () => {
       expect(selectLinks[0]?.getAttribute('href')).toBe(
         '/organisations/org-123/registrations/reg-001/reports/2026/monthly/1/submissions/1'
       )
-      expect(selectLinks[0]?.textContent).toContain('Select')
+      expect(selectLinks[0]?.textContent).toContain('Create draft')
     })
 
     it('should not display Quarterly subheading', async ({ server }) => {
@@ -551,7 +551,9 @@ describe('#listReportsController', () => {
       ])
     })
 
-    it('should display Continue link instead of Select', async ({ server }) => {
+    it('should display Continue link instead of Create draft', async ({
+      server
+    }) => {
       const { result } = await server.inject({
         method: 'GET',
         url: accreditedUrl,
@@ -803,7 +805,7 @@ describe('#listReportsController', () => {
             '20 March 2026',
             'Continue February 2026'
           ],
-          ['March 2026', '', '20 April 2026', 'Select March 2026']
+          ['March 2026', '', '20 April 2026', 'Create draft March 2026']
         ]
       })
     })
@@ -991,7 +993,7 @@ describe('#listReportsController', () => {
       expect(table?.textContent).toContain('Quarter 1, 2026')
     })
 
-    it('should display Select links for exporter', async ({ server }) => {
+    it('should display Create draft links for exporter', async ({ server }) => {
       const { result } = await server.inject({
         method: 'GET',
         url: exporterUrl,
@@ -1007,7 +1009,7 @@ describe('#listReportsController', () => {
       expect(selectLinks[0]?.getAttribute('href')).toBe(
         '/organisations/org-456/registrations/reg-002/reports/2026/quarterly/1/submissions/1'
       )
-      expect(selectLinks[0]?.textContent).toContain('Select')
+      expect(selectLinks[0]?.textContent).toContain('Create draft')
     })
 
     it('should link Continue to tonnes-not-exported for in-progress report', async ({
@@ -1137,7 +1139,7 @@ describe('#listReportsController', () => {
       vi.mocked(fetchReportingPeriods).mockResolvedValue(quarterlyResponse)
     })
 
-    it('should display Select links for reprocessor periods', async ({
+    it('should display Create draft links for reprocessor periods', async ({
       server
     }) => {
       const { result } = await server.inject({
@@ -1155,7 +1157,7 @@ describe('#listReportsController', () => {
       expect(link?.getAttribute('href')).toBe(
         '/organisations/org-789/registrations/reg-003/reports/2026/quarterly/1/submissions/1'
       )
-      expect(link?.textContent).toContain('Select')
+      expect(link?.textContent).toContain('Create draft')
 
       const hidden = link?.querySelector('.govuk-visually-hidden')
       expect(hidden?.textContent).toBe('Quarter 1, 2026')


### PR DESCRIPTION
Ticket: [PAE-1574](https://eaflood.atlassian.net/browse/PAE-1574)
## Changes

-  Change new report creation link to `Create draft` from `Select`
- 
<img width="1568" height="716" alt="image" src="https://github.com/user-attachments/assets/e8c9dd2f-7ae0-433e-b8d1-f921a4be0ea3" />


[PAE-1574]: https://eaflood.atlassian.net/browse/PAE-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ